### PR TITLE
Add Trino production readiness and simplify catalog API

### DIFF
--- a/configs/trino/config.properties
+++ b/configs/trino/config.properties
@@ -1,7 +1,25 @@
 coordinator=true
+# In docker-compose (dev), the coordinator also executes queries so it works
+# without workers. In production (k8s), set this to false with dedicated workers.
 node-scheduler.include-coordinator=true
 http-server.http.port=8080
 discovery.uri=http://localhost:8080
 
+# Web UI — type any username to log in, all users' queries are visible.
+# Query visibility is controlled by the access control plugin (filterViewQueryOwnedBy).
+web-ui.enabled=true
+web-ui.authentication.type=insecure
+
 # Enable dynamic catalog management (CREATE/DROP CATALOG via SQL)
 catalog.management=dynamic
+
+# Memory limits
+query.max-memory=2GB
+query.max-memory-per-node=1GB
+
+# Query timeouts — kill runaway queries
+query.max-execution-time=30m
+query.max-run-time=45m
+
+# Graceful shutdown — let in-flight queries finish before container stop
+shutdown.grace-period=120s

--- a/configs/trino/resource-groups-README.md
+++ b/configs/trino/resource-groups-README.md
@@ -1,0 +1,44 @@
+# Trino Resource Groups Configuration
+
+Documentation for `resource-groups.json`. Trino's JSON parser does not support
+comments, so this companion file explains each setting.
+
+## Structure
+
+```
+global (parent group)
+  └── user-{username} (per-user child group, auto-created)
+```
+
+## Root Group: `global`
+
+| Setting | Value | Meaning |
+|---------|-------|---------|
+| `softMemoryLimit` | `100%` | This group can use all cluster query memory |
+| `hardConcurrencyLimit` | `20` | Max 20 queries running concurrently across ALL users |
+| `maxQueued` | `200` | Max 200 queries waiting in queue. Beyond this, new queries are rejected |
+| `schedulingPolicy` | `weighted_fair` | Each active user gets an equal share of capacity. 3 active users = ~1/3 each |
+
+## Per-User Group: `user-${USER}`
+
+`${USER}` is replaced by the Trino username from the connection.
+
+| Setting | Value | Meaning |
+|---------|-------|---------|
+| `softMemoryLimit` | `30%` | One user's queries can use at most 30% of cluster memory. Soft = won't kill running queries, but blocks new ones |
+| `hardConcurrencyLimit` | `5` | Max 5 concurrent queries per user. 6th query queues |
+| `maxQueued` | `20` | Max 20 queued queries per user. Beyond this, rejected immediately |
+
+## Selectors
+
+Selectors route incoming queries to resource groups. Evaluated in order, first match wins.
+
+| Setting | Value | Meaning |
+|---------|-------|---------|
+| `user` | `.*` | Matches all usernames (regex) |
+| `group` | `global.user-${USER}` | Routes to per-user sub-group (e.g., user `tgu` → `global.user-tgu`) |
+
+To add special handling for specific users, add a selector above the catch-all:
+```json
+{"user": "admin", "group": "global.admin-group"}
+```

--- a/configs/trino/resource-groups.json
+++ b/configs/trino/resource-groups.json
@@ -1,0 +1,25 @@
+{
+  "rootGroups": [
+    {
+      "name": "global",
+      "softMemoryLimit": "100%",
+      "hardConcurrencyLimit": 20,
+      "maxQueued": 200,
+      "schedulingPolicy": "weighted_fair",
+      "subGroups": [
+        {
+          "name": "user-${USER}",
+          "softMemoryLimit": "30%",
+          "hardConcurrencyLimit": 5,
+          "maxQueued": 20
+        }
+      ]
+    }
+  ],
+  "selectors": [
+    {
+      "user": ".*",
+      "group": "global.user-${USER}"
+    }
+  ]
+}

--- a/configs/trino/resource-groups.properties
+++ b/configs/trino/resource-groups.properties
@@ -1,0 +1,2 @@
+resource-groups.configuration-manager=file
+resource-groups.config-file=/etc/trino/resource-groups.json

--- a/configs/trino/worker-config.properties
+++ b/configs/trino/worker-config.properties
@@ -1,0 +1,10 @@
+coordinator=false
+http-server.http.port=8080
+discovery.uri=http://trino:8080
+
+# Enable dynamic catalog management (workers must match coordinator)
+catalog.management=dynamic
+
+# Memory limits (must match coordinator)
+query.max-memory=2GB
+query.max-memory-per-node=1GB

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -259,6 +259,8 @@ services:
       - spark-master
 
   trino:
+    # Trino coordinator — handles query planning, scheduling, and client connections.
+    # Workers register with the coordinator via discovery.uri.
     # image: ghcr.io/berdatalakehouse/trino_access_control:main
     build:
       context: ../trino_access_control
@@ -270,9 +272,32 @@ services:
     volumes:
       - ./configs/trino/config.properties:/etc/trino/config.properties
       - ./configs/trino/access-control.properties:/etc/trino/access-control.properties
+      - ./configs/trino/resource-groups.properties:/etc/trino/resource-groups.properties
+      - ./configs/trino/resource-groups.json:/etc/trino/resource-groups.json
     depends_on:
       - hive-metastore
       - minio
+    healthcheck:
+      test: ["CMD", "curl", "-sf", "http://localhost:8080/v1/info"]
+      interval: 30s
+      timeout: 10s
+      retries: 5
+    stop_grace_period: 150s
+
+  trino-worker:
+    # Trino worker — executes query fragments assigned by the coordinator.
+    # Scale with: docker compose up -d --scale trino-worker=N
+    # image: ghcr.io/berdatalakehouse/trino_access_control:main
+    build:
+      context: ../trino_access_control
+      dockerfile: Dockerfile
+      args:
+        TRINO_VERSION: "479"
+    volumes:
+      - ./configs/trino/worker-config.properties:/etc/trino/config.properties
+    depends_on:
+      trino:
+        condition: service_healthy
     healthcheck:
       test: ["CMD", "curl", "-sf", "http://localhost:8080/v1/info"]
       interval: 30s

--- a/notebook_utils/berdl_notebook_utils/setup_trino_session.py
+++ b/notebook_utils/berdl_notebook_utils/setup_trino_session.py
@@ -8,7 +8,7 @@ configures per-user S3 access for Spark.
 Architecture:
     1. Fetch user's MinIO credentials from governance API
     2. Create a per-user dynamic catalog via CREATE CATALOG
-    3. Return a trino.dbapi connection + catalog name
+    3. Return a trino.dbapi Connection configured to use the per-user catalog as the default
 
 The user's catalog (e.g., "u_tgu") has their own MinIO credentials,
 so S3 access is scoped to what the governance API grants them — same

--- a/notebook_utils/berdl_notebook_utils/setup_trino_session.py
+++ b/notebook_utils/berdl_notebook_utils/setup_trino_session.py
@@ -10,14 +10,13 @@ Architecture:
     2. Create a per-user dynamic catalog via CREATE CATALOG
     3. Return a trino.dbapi connection + catalog name
 
-The user's catalog (e.g., "u_tgu_lake") has their own MinIO credentials,
+The user's catalog (e.g., "u_tgu") has their own MinIO credentials,
 so S3 access is scoped to what the governance API grants them — same
 security model as Spark sessions.
 """
 
 import logging
 import re
-from typing import NamedTuple
 
 import trino
 
@@ -28,7 +27,7 @@ logger = logging.getLogger(__name__)
 
 # Connectors allowed in CREATE CATALOG statements (SQL-injection allowlist).
 #
-# Each user gets a per-user dynamic catalog (e.g. "u_{username}_lake") that points
+# Each user gets a per-user dynamic catalog (e.g. "u_{username}") that points
 # at the shared Hive Metastore but uses the user's own MinIO credentials.
 # The berdl-namespace-isolation access-control plugin then filters visibility:
 #   - Personal namespaces:  schemas matching  u_{username}__*
@@ -47,19 +46,15 @@ ALLOWED_CONNECTORS = frozenset(
 )
 
 
-class TrinoSession(NamedTuple):
-    """Return type for get_trino_connection()."""
-
-    connection: trino.dbapi.Connection
-    catalog: str
-
-
 def _sanitize_identifier(value: str) -> str:
     """
     Sanitize a string into a valid Trino identifier component.
 
     Trino catalog names must be lowercase alphanumeric + underscores.
-    Used for both usernames and catalog suffixes.
+
+    IMPORTANT: This logic must match ``sanitizeIdentifier()`` in the Trino
+    access control plugin (BerdlSystemAccessControl.java) so that catalog
+    names built here align with the ownership prefixes checked there.
     """
     return re.sub(r"[^a-z0-9_]", "_", value.lower())
 
@@ -121,7 +116,7 @@ def _create_dynamic_catalog(
 
     Skips creation if the catalog is already loaded (e.g. from a previous
     session or static .properties file).  The access control plugin allows
-    CREATE CATALOG for catalogs matching u_{user}_*.
+    CREATE CATALOG for catalogs matching u_{user}*.
     """
     if _catalog_exists(cursor, catalog_name):
         logger.info(f"Catalog '{catalog_name}' already exists, skipping creation")
@@ -145,10 +140,9 @@ def _create_dynamic_catalog(
 def get_trino_connection(
     host: str | None = None,
     port: int | None = None,
-    catalog_suffix: str = "lake",
     connector: str = "delta_lake",
     settings: BERDLSettings | None = None,
-) -> TrinoSession:
+) -> trino.dbapi.Connection:
     """
     Create a Trino connection with a per-user dynamic catalog.
 
@@ -156,32 +150,29 @@ def get_trino_connection(
     injected into a dynamic catalog, giving each user isolated S3 access
     — the same model as get_spark_session().
 
+    The connection's default catalog is set automatically, so queries
+    use ``schema.table`` format — same as Spark.
+
     Args:
         host: Trino coordinator hostname. Defaults to TRINO_HOST env var or "trino".
         port: Trino coordinator port. Defaults to TRINO_PORT env var or 8080.
-        catalog_suffix: Suffix for the catalog name. The full name is
-                        "u_{username}_{suffix}" (e.g., "u_tgu_lake").
         connector: Trino connector to use. Defaults to "delta_lake".
                    Use "hive" if you need Hive connector instead.
         settings: BERDLSettings instance. If None, reads from environment.
 
     Returns:
-        TrinoSession(connection, catalog) — a named tuple with:
-            - connection: trino.dbapi.Connection ready for queries
-            - catalog: str catalog name to use in queries
+        trino.dbapi.Connection with the default catalog set to the user's
+        dynamic catalog.
 
     Example:
-        >>> conn, catalog = get_trino_connection()
+        >>> conn = get_trino_connection()
         >>> cursor = conn.cursor()
-        >>> cursor.execute(f"SHOW SCHEMAS FROM {catalog}")
-        >>> print(cursor.fetchall())
-
-        >>> # Query a table
-        >>> cursor.execute(f"SELECT * FROM {catalog}.my_schema.my_table LIMIT 10")
+        >>> cursor.execute("SELECT * FROM my_schema.my_table LIMIT 10")
         >>> df = cursor.fetch_pandas_all()
 
-        >>> # With tenant warehouse
-        >>> conn, catalog = get_trino_connection(catalog_suffix="research_team")
+        >>> # SHOW SCHEMAS also works without catalog prefix
+        >>> cursor.execute("SHOW SCHEMAS")
+        >>> print(cursor.fetchall())
     """
     if settings is None:
         get_settings.cache_clear()
@@ -195,10 +186,9 @@ def get_trino_connection(
     credentials = get_minio_credentials()
     username = settings.USER
 
-    # Build catalog name: u_{username}_{suffix}
+    # Build catalog name: u_{username}
     safe_username = _sanitize_identifier(username)
-    safe_suffix = _sanitize_identifier(catalog_suffix)
-    catalog_name = f"u_{safe_username}_{safe_suffix}"
+    catalog_name = f"u_{safe_username}"
 
     logger.info(f"Setting up Trino connection for user={username}, catalog={catalog_name}")
 
@@ -222,6 +212,10 @@ def get_trino_connection(
     cursor = conn.cursor()
     _create_dynamic_catalog(cursor, catalog_name, connector, properties)
 
+    # Set the default catalog on the connection so users can write
+    # schema.table queries without a catalog prefix — same UX as Spark.
+    conn._client_session.catalog = catalog_name
+
     logger.info(f"Trino session ready: host={trino_host}:{trino_port}, user={username}, catalog={catalog_name}")
 
-    return TrinoSession(connection=conn, catalog=catalog_name)
+    return conn

--- a/notebook_utils/tests/test_setup_trino_session.py
+++ b/notebook_utils/tests/test_setup_trino_session.py
@@ -8,7 +8,6 @@ from governance_client.models import CredentialsResponse
 from berdl_notebook_utils.berdl_settings import BERDLSettings
 from berdl_notebook_utils.setup_trino_session import (
     ALLOWED_CONNECTORS,
-    TrinoSession,
     _build_catalog_properties,
     _catalog_exists,
     _create_dynamic_catalog,
@@ -217,16 +216,29 @@ class TestGetTrinoConnection:
     @patch("berdl_notebook_utils.setup_trino_session._create_dynamic_catalog")
     @patch("berdl_notebook_utils.setup_trino_session.trino")
     @patch("berdl_notebook_utils.setup_trino_session.get_minio_credentials")
-    def test_returns_trino_session(self, mock_get_creds, mock_trino, mock_create_cat, mock_settings, mock_credentials):
+    def test_returns_connection(self, mock_get_creds, mock_trino, mock_create_cat, mock_settings, mock_credentials):
         mock_get_creds.return_value = mock_credentials
         mock_conn = MagicMock()
         mock_trino.dbapi.connect.return_value = mock_conn
 
         result = get_trino_connection(settings=mock_settings)
 
-        assert isinstance(result, TrinoSession)
-        assert result.connection is mock_conn
-        assert result.catalog == "u_testuser_lake"
+        assert result is mock_conn
+
+    @patch("berdl_notebook_utils.setup_trino_session._create_dynamic_catalog")
+    @patch("berdl_notebook_utils.setup_trino_session.trino")
+    @patch("berdl_notebook_utils.setup_trino_session.get_minio_credentials")
+    def test_sets_default_catalog_on_connection(
+        self, mock_get_creds, mock_trino, mock_create_cat, mock_settings, mock_credentials
+    ):
+        """Connection's default catalog is set so queries use schema.table without prefix."""
+        mock_get_creds.return_value = mock_credentials
+        mock_conn = MagicMock()
+        mock_trino.dbapi.connect.return_value = mock_conn
+
+        get_trino_connection(settings=mock_settings)
+
+        assert mock_conn._client_session.catalog == "u_testuser"
 
     @patch("berdl_notebook_utils.setup_trino_session._create_dynamic_catalog")
     @patch("berdl_notebook_utils.setup_trino_session.trino")
@@ -303,17 +315,6 @@ class TestGetTrinoConnection:
     @patch("berdl_notebook_utils.setup_trino_session._create_dynamic_catalog")
     @patch("berdl_notebook_utils.setup_trino_session.trino")
     @patch("berdl_notebook_utils.setup_trino_session.get_minio_credentials")
-    def test_custom_catalog_suffix(self, mock_get_creds, mock_trino, mock_create_cat, mock_settings, mock_credentials):
-        mock_get_creds.return_value = mock_credentials
-        mock_trino.dbapi.connect.return_value = MagicMock()
-
-        result = get_trino_connection(catalog_suffix="research_team", settings=mock_settings)
-
-        assert result.catalog == "u_testuser_research_team"
-
-    @patch("berdl_notebook_utils.setup_trino_session._create_dynamic_catalog")
-    @patch("berdl_notebook_utils.setup_trino_session.trino")
-    @patch("berdl_notebook_utils.setup_trino_session.get_minio_credentials")
     def test_custom_connector(self, mock_get_creds, mock_trino, mock_create_cat, mock_settings, mock_credentials):
         mock_get_creds.return_value = mock_credentials
         mock_conn = MagicMock()
@@ -353,7 +354,7 @@ class TestGetTrinoConnection:
 
         result = get_trino_connection(settings=mock_settings)
 
-        assert result.catalog == "u_my_user_name_lake"
+        assert result._client_session.catalog == "u_my_user_name"
 
     @patch("berdl_notebook_utils.setup_trino_session._create_dynamic_catalog")
     @patch("berdl_notebook_utils.setup_trino_session.trino")
@@ -376,7 +377,7 @@ class TestGetTrinoConnection:
 
         mock_get_settings.cache_clear.assert_called_once()
         mock_get_settings.assert_called_once()
-        assert result.catalog == "u_autouser_lake"
+        assert result._client_session.catalog == "u_autouser"
 
     @patch("berdl_notebook_utils.setup_trino_session._create_dynamic_catalog")
     @patch("berdl_notebook_utils.setup_trino_session.trino")
@@ -395,30 +396,6 @@ class TestGetTrinoConnection:
         mock_conn.cursor.assert_called_once()
         mock_create_cat.assert_called_once()
         assert mock_create_cat.call_args[0][0] is mock_cursor
-
-
-# ---------------------------------------------------------------------------
-# TrinoSession named tuple
-# ---------------------------------------------------------------------------
-class TestTrinoSession:
-    def test_is_named_tuple(self):
-        conn = MagicMock()
-        session = TrinoSession(connection=conn, catalog="my_cat")
-        assert session.connection is conn
-        assert session.catalog == "my_cat"
-
-    def test_unpacking(self):
-        conn = MagicMock()
-        session = TrinoSession(connection=conn, catalog="my_cat")
-        unpacked_conn, unpacked_cat = session
-        assert unpacked_conn is conn
-        assert unpacked_cat == "my_cat"
-
-    def test_indexing(self):
-        conn = MagicMock()
-        session = TrinoSession(connection=conn, catalog="my_cat")
-        assert session[0] is conn
-        assert session[1] == "my_cat"
 
 
 # ---------------------------------------------------------------------------
@@ -482,57 +459,6 @@ class TestCreateDynamicCatalogSecurity:
         create_sql = cursor.execute.call_args_list[1][0][0]
         assert "secret''with''quotes" in create_sql
         assert "secret'with'quotes" not in create_sql
-
-
-# ---------------------------------------------------------------------------
-# get_trino_connection — catalog_suffix sanitization
-# ---------------------------------------------------------------------------
-class TestGetTrinoConnectionSuffixSanitization:
-    @pytest.fixture()
-    def mock_settings(self):
-        settings = MagicMock(spec=BERDLSettings)
-        settings.USER = "testuser"
-        settings.MINIO_ENDPOINT_URL = "http://minio:9000"
-        settings.MINIO_SECURE = False
-        settings.BERDL_HIVE_METASTORE_URI = "thrift://hive:9083"
-        settings.TRINO_HOST = "trino"
-        settings.TRINO_PORT = 8080
-        settings.KBASE_AUTH_TOKEN = "fake-kbase-token"
-        return settings
-
-    @pytest.fixture()
-    def mock_credentials(self):
-        return CredentialsResponse(
-            username="testuser",
-            access_key="test_access_key",
-            secret_key="test_secret_key",
-        )
-
-    @patch("berdl_notebook_utils.setup_trino_session._create_dynamic_catalog")
-    @patch("berdl_notebook_utils.setup_trino_session.trino")
-    @patch("berdl_notebook_utils.setup_trino_session.get_minio_credentials")
-    def test_suffix_with_special_chars_sanitized(
-        self, mock_get_creds, mock_trino, mock_create_cat, mock_settings, mock_credentials
-    ):
-        mock_get_creds.return_value = mock_credentials
-        mock_trino.dbapi.connect.return_value = MagicMock()
-
-        result = get_trino_connection(catalog_suffix="My-Team.v2", settings=mock_settings)
-
-        assert result.catalog == "u_testuser_my_team_v2"
-
-    @patch("berdl_notebook_utils.setup_trino_session._create_dynamic_catalog")
-    @patch("berdl_notebook_utils.setup_trino_session.trino")
-    @patch("berdl_notebook_utils.setup_trino_session.get_minio_credentials")
-    def test_suffix_uppercase_lowercased(
-        self, mock_get_creds, mock_trino, mock_create_cat, mock_settings, mock_credentials
-    ):
-        mock_get_creds.return_value = mock_credentials
-        mock_trino.dbapi.connect.return_value = MagicMock()
-
-        result = get_trino_connection(catalog_suffix="RESEARCH", settings=mock_settings)
-
-        assert result.catalog == "u_testuser_research"
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
Trino infrastructure:
- Add coordinator/worker separation in docker-compose
- Add resource group config for per-user fair scheduling
- Add memory limits, query timeouts, and graceful shutdown
- Configure Web UI with insecure auth for dev

Trino session API:
- Remove catalog_suffix parameter — each user gets a single u_{username} catalog
- Return plain Connection instead of TrinoSession named tuple
- Set default catalog on connection so queries use schema.table without prefix
- Add sanitizeIdentifier() alignment note with Java plugin