### PR TITLE
Add tenant parameter to get_databases()

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-ARG BASE_TAG=pr-130
+ARG BASE_TAG=pr-144
 ARG BASE_REGISTRY=ghcr.io/berdatalakehouse/
 FROM ${BASE_REGISTRY}spark_notebook_base:${BASE_TAG}
 

--- a/notebook_utils/berdl_notebook_utils/spark/data_store.py
+++ b/notebook_utils/berdl_notebook_utils/spark/data_store.py
@@ -153,6 +153,7 @@ def get_databases(
     use_hms: bool = True,
     return_json: bool = True,
     filter_by_namespace: bool = True,
+    tenant: Optional[str] = None,
 ) -> Union[str, List[str]]:
     """
     Get the list of databases in the Hive metastore.
@@ -167,6 +168,10 @@ def get_databases(
                            - Group/tenant databases (groupname_*)
                            - Databases shared with the user (from accessible paths API)
                            When False, returns all databases in the metastore.
+        tenant: Optional tenant/group name to filter to a single tenant's databases.
+                When provided, only returns databases matching that tenant's namespace prefix
+                (e.g. tenant="globalusers" returns only globalusers_* databases).
+                Implies filter_by_namespace=True.
 
     Returns:
         List of database names, either as JSON string or raw list
@@ -179,6 +184,18 @@ def get_databases(
         databases = hive_metastore.get_databases()
     else:
         databases = _execute_with_spark(_get_dbs, spark)
+
+    # Single-tenant filter: just get that tenant's prefix and filter
+    if tenant is not None:
+        try:
+            tenant_prefix_response = _cached_get_namespace_prefix(tenant=tenant)
+            prefix = tenant_prefix_response.tenant_namespace_prefix
+            if not isinstance(prefix, str):
+                raise ValueError(f"No tenant namespace prefix returned for tenant '{tenant}'")
+            databases = sorted([db for db in databases if db.startswith(prefix)])
+        except Exception as e:
+            raise Exception(f"Could not filter databases for tenant '{tenant}': {e}") from e
+        return _format_output(databases, return_json)
 
     # Apply filtering: owned databases (fast) + shared databases (API call)
     if filter_by_namespace:

--- a/notebook_utils/tests/spark/test_data_store.py
+++ b/notebook_utils/tests/spark/test_data_store.py
@@ -175,6 +175,71 @@ class TestGetDatabases:
         assert "u_test__db1" in result
 
 
+class TestGetDatabasesByTenant:
+    """Tests for get_databases with tenant parameter."""
+
+    @patch("berdl_notebook_utils.spark.data_store._cached_get_namespace_prefix")
+    @patch("berdl_notebook_utils.spark.data_store.hive_metastore")
+    def test_get_databases_single_tenant(self, mock_hms, mock_prefix):
+        """Test get_databases with tenant filters to that tenant's prefix only."""
+        mock_hms.get_databases.return_value = [
+            "u_test__db1",
+            "globalusers_shared",
+            "globalusers_analytics",
+            "teamx_project",
+        ]
+        mock_prefix.return_value = Mock(tenant_namespace_prefix="globalusers_")
+
+        result = get_databases(use_hms=True, tenant="globalusers", return_json=False)
+
+        assert result == ["globalusers_analytics", "globalusers_shared"]
+        mock_prefix.assert_called_once_with(tenant="globalusers")
+
+    @patch("berdl_notebook_utils.spark.data_store._cached_get_namespace_prefix")
+    @patch("berdl_notebook_utils.spark.data_store.hive_metastore")
+    def test_get_databases_tenant_no_matches(self, mock_hms, mock_prefix):
+        """Test get_databases with tenant that has no matching databases."""
+        mock_hms.get_databases.return_value = ["u_test__db1", "globalusers_shared"]
+        mock_prefix.return_value = Mock(tenant_namespace_prefix="teamx_")
+
+        result = get_databases(use_hms=True, tenant="teamx", return_json=False)
+
+        assert result == []
+
+    @patch("berdl_notebook_utils.spark.data_store._cached_get_namespace_prefix")
+    @patch("berdl_notebook_utils.spark.data_store.hive_metastore")
+    def test_get_databases_tenant_returns_json(self, mock_hms, mock_prefix):
+        """Test get_databases with tenant returns JSON when return_json=True."""
+        mock_hms.get_databases.return_value = ["globalusers_db1"]
+        mock_prefix.return_value = Mock(tenant_namespace_prefix="globalusers_")
+
+        result = get_databases(use_hms=True, tenant="globalusers", return_json=True)
+
+        assert json.loads(result) == ["globalusers_db1"]
+
+    @patch("berdl_notebook_utils.spark.data_store._cached_get_namespace_prefix")
+    @patch("berdl_notebook_utils.spark.data_store.hive_metastore")
+    def test_get_databases_tenant_error_raises(self, mock_hms, mock_prefix):
+        """Test get_databases with tenant raises on API error."""
+        mock_hms.get_databases.return_value = ["db1"]
+        mock_prefix.side_effect = Exception("API error")
+
+        with pytest.raises(Exception, match="Could not filter databases for tenant 'badteam'"):
+            get_databases(use_hms=True, tenant="badteam", return_json=False)
+
+    @patch("berdl_notebook_utils.spark.data_store._cached_get_namespace_prefix")
+    @patch("berdl_notebook_utils.spark.data_store.hive_metastore")
+    def test_get_databases_tenant_invalid_prefix_raises(self, mock_hms, mock_prefix):
+        """Test get_databases raises when tenant returns Unset/None prefix."""
+        from governance_client.types import UNSET
+
+        mock_hms.get_databases.return_value = ["db1"]
+        mock_prefix.return_value = Mock(tenant_namespace_prefix=UNSET)
+
+        with pytest.raises(Exception, match="Could not filter databases for tenant"):
+            get_databases(use_hms=True, tenant="badteam", return_json=False)
+
+
 class TestGetTables:
     """Tests for get_tables function."""
 


### PR DESCRIPTION
## Summary
- Add optional `tenant` parameter to `get_databases()` in `data_store.py` to filter databases to a single tenant's namespace prefix
- e.g. `get_databases(tenant="globalusers")` returns only `globalusers_*` databases
- Includes validation when the governance API returns an invalid prefix (Unset/None)
- 5 new unit tests covering: filtering, no matches, JSON output, API errors, invalid prefix

## Test plan
- [x] `uv run pytest tests/spark/test_data_store.py::TestGetDatabasesByTenant -v` — 5/5 pass
- [ ] Verify in notebook: `get_databases(spark, tenant="globalusers", return_json=False)`