### PR TITLE
Update ingest library to v0.0.8 for spark_notebook image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -23,7 +23,7 @@ RUN python3 /tmp/patch_s3contents.py && rm /tmp/patch_s3contents.py
 COPY notebook_utils /tmp/notebook_utils
 RUN eval "$(conda shell.bash hook)" && uv pip install --no-deps --system /tmp/notebook_utils && rm -rf /tmp/notebook_utils
 
-RUN eval "$(conda shell.bash hook)" && uv pip install --no-deps --system "git+https://github.com/kbase/data-lakehouse-ingest.git@v0.0.7"
+RUN eval "$(conda shell.bash hook)" && uv pip install --no-deps --system "git+https://github.com/kbase/data-lakehouse-ingest.git@v0.0.8"
 
 WORKDIR /home
 ENTRYPOINT ["/entrypoint.sh"]


### PR DESCRIPTION
This PR updates the spark_notebook Docker image to use the newly released data-lakehouse-ingest v0.0.8.

Change:
Updated pip install reference from @v0.0.7 to @v0.0.8