### PR TITLE
Fix Hive metastore client config: remove version/jars overrides and align URI key

### DIFF
--- a/configs/spark-defaults.conf.template
+++ b/configs/spark-defaults.conf.template
@@ -88,7 +88,7 @@ spark.sql.catalogImplementation=hive
 # spark.sql.hive.metastore.version=4.0.0
 # spark.sql.hive.metastore.jars=path
 # spark.sql.hive.metastore.jars.path=/usr/local/spark/jars/*
-# hive.metastore.uris will be set dynamically from BERDL_HIVE_METASTORE_URI
+# spark.hadoop.hive.metastore.uris will be set dynamically from BERDL_HIVE_METASTORE_URI
 
 # MinIO S3 configuration - will be set dynamically by startup script
 # spark.hadoop.fs.s3a.endpoint will be set from MINIO_ENDPOINT_URL

--- a/configs/spark-defaults.conf.template
+++ b/configs/spark-defaults.conf.template
@@ -77,9 +77,17 @@ spark.eventLog.compression.codec=zstd
 
 # Hive metastore
 spark.sql.catalogImplementation=hive
-spark.sql.hive.metastore.version=4.0.0
-spark.sql.hive.metastore.jars=path
-spark.sql.hive.metastore.jars.path=/usr/local/spark/jars/*
+# Disabled: forcing metastore.version=4.0.0 selects Spark's Shim_v4_0, which
+# reflectively calls Hive.alterTable(String, Table, EnvironmentContext, boolean) —
+# a 4-arg overload that only exists in Hive 4.x. The jars under
+# /usr/local/spark/jars/ are Hive 2.3.10 (what Spark 4.0 ships with), so the
+# lookup throws NoSuchMethodException on any Delta saveAsTable / overwriteSchema
+# path that triggers UpdateCatalog. Letting Spark fall back to its built-in
+# Hive 2.3 client + Shim_v2_3 works fine against the Hive 4.0 metastore over
+# Thrift (the wire protocol is backward compatible).
+# spark.sql.hive.metastore.version=4.0.0
+# spark.sql.hive.metastore.jars=path
+# spark.sql.hive.metastore.jars.path=/usr/local/spark/jars/*
 # hive.metastore.uris will be set dynamically from BERDL_HIVE_METASTORE_URI
 
 # MinIO S3 configuration - will be set dynamically by startup script

--- a/notebook_utils/berdl_notebook_utils/setup_spark_session.py
+++ b/notebook_utils/berdl_notebook_utils/setup_spark_session.py
@@ -177,12 +177,13 @@ def _get_delta_conf() -> dict[str, str]:
 
 
 def _get_hive_conf(settings: BERDLSettings) -> dict[str, str]:
+    # Do not set spark.sql.hive.metastore.version / .jars — forcing version=4.0.0
+    # selects Shim_v4_0, which calls a 4-arg Hive.alterTable overload that only
+    # exists in Hive 4.x clients. The bundled jars are Hive 2.3.10. See
+    # configs/spark-defaults.conf.template for the full rationale.
     return {
-        "hive.metastore.uris": str(settings.BERDL_HIVE_METASTORE_URI),
+        "spark.hadoop.hive.metastore.uris": str(settings.BERDL_HIVE_METASTORE_URI),
         "spark.sql.catalogImplementation": "hive",
-        "spark.sql.hive.metastore.version": "4.0.0",
-        "spark.sql.hive.metastore.jars": "path",
-        "spark.sql.hive.metastore.jars.path": "/usr/local/spark/jars/*",
     }
 
 


### PR DESCRIPTION
Removes `spark.sql.hive.metastore.version=4.0.0` and the matching `metastore.jars` lines from both `configs/spark-defaults.conf.template` (Spark Connect server config) and `notebook_utils/berdl_notebook_utils/setup_spark_session.py` (client-side `_get_hive_conf`). These were selecting Spark's `Shim_v4_0` and reflectively calling a 4-arg `Hive.alterTable` overload that only exists in Hive 4.x — but the bundled jars are Hive 2.3.10, so any Delta `saveAsTable` / `overwriteSchema` write that triggered `UpdateCatalog` threw `NoSuchMethodException`. In Spark Connect mode the client-side overrides were silently rejected as immutable and masked by a suppressed warning; in legacy (`use_spark_connect=False`) mode they took effect and reproduced the bug. Falls back to Spark's built-in Hive 2.3 client + `Shim_v2_3`, which works against the Hive 4.0 metastore over Thrift since the wire protocol is backward compatible. Also aligns the metastore URI key on the client side to `spark.hadoop.hive.metastore.uris` (the Hadoop-prefixed form Spark forwards into Hadoop config) to match what `connect_server.py` writes server-side, and updates the template comment to refer to the actual key.