### PR TITLE
Add in-process TTL cache for governance API calls

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-ARG BASE_TAG=pr-153
+ARG BASE_TAG=pr-156
 ARG BASE_REGISTRY=ghcr.io/berdatalakehouse/
 FROM ${BASE_REGISTRY}spark_notebook_base:${BASE_TAG}
 

--- a/notebook_utils/berdl_notebook_utils/minio_governance/_cache.py
+++ b/notebook_utils/berdl_notebook_utils/minio_governance/_cache.py
@@ -1,0 +1,23 @@
+"""In-process TTL caches for read-heavy governance calls.
+
+The extension's tenants landing page hits list_tenants() and get_my_groups()
+on every load, which scales with tenant count. These caches match the 300s
+TTL used elsewhere in the monorepo (trino_access_control plugin,
+minio_manager_service/kbase_profile_client) so staleness windows are
+consistent across the platform.
+
+Mutations in this package call invalidate_all() after success so changes
+made in the same notebook process are reflected on the next read.
+"""
+
+from cacheout import Cache
+
+_TTL_SECONDS = 3600
+
+tenants_cache: Cache = Cache(maxsize=1, ttl=_TTL_SECONDS)
+groups_cache: Cache = Cache(maxsize=1, ttl=_TTL_SECONDS)
+
+
+def invalidate_all() -> None:
+    tenants_cache.clear()
+    groups_cache.clear()

--- a/notebook_utils/berdl_notebook_utils/minio_governance/_cache.py
+++ b/notebook_utils/berdl_notebook_utils/minio_governance/_cache.py
@@ -1,10 +1,8 @@
 """In-process TTL caches for read-heavy governance calls.
 
 The extension's tenants landing page hits list_tenants() and get_my_groups()
-on every load, which scales with tenant count. These caches match the 300s
-TTL used elsewhere in the monorepo (trino_access_control plugin,
-minio_manager_service/kbase_profile_client) so staleness windows are
-consistent across the platform.
+on every load, which scales with tenant count. These caches use a 1-hour
+TTL to reduce repeated read traffic while keeping staleness bounded.
 
 Mutations in this package call invalidate_all() after success so changes
 made in the same notebook process are reflected on the next read.

--- a/notebook_utils/berdl_notebook_utils/minio_governance/operations.py
+++ b/notebook_utils/berdl_notebook_utils/minio_governance/operations.py
@@ -299,7 +299,7 @@ def get_my_groups(force_refresh: bool = False) -> UserGroupsResponse:
     """
     Get list of groups the current user belongs to.
 
-    Results are cached in-process for 300s. Mutations in this package that
+    Results are cached in-process for 3600s. Mutations in this package that
     can change the current user's group membership (add/remove_tenant_member,
     add/remove_group_member, create_tenant_and_assign_users) bust the cache.
 

--- a/notebook_utils/berdl_notebook_utils/minio_governance/operations.py
+++ b/notebook_utils/berdl_notebook_utils/minio_governance/operations.py
@@ -66,6 +66,7 @@ from governance_client.types import UNSET
 
 from .. import get_settings
 from ..clients import get_governance_client
+from ._cache import groups_cache, invalidate_all
 
 # =============================================================================
 # TYPE DEFINITIONS
@@ -86,6 +87,8 @@ class TenantCreationResult(TypedDict):
 # Default BERDL storage configuration
 SQL_WAREHOUSE_BUCKET = "cdm-lake"  # TODO: change to berdl-lake
 SQL_USER_WAREHOUSE_PATH = "users-sql-warehouse"
+
+_GROUPS_CACHE_KEY = "me"
 
 # =============================================================================
 # HELPER FUNCTIONS
@@ -292,13 +295,25 @@ def get_my_policies() -> UserPoliciesResponse:
     return response
 
 
-def get_my_groups() -> UserGroupsResponse:
+def get_my_groups(force_refresh: bool = False) -> UserGroupsResponse:
     """
     Get list of groups the current user belongs to.
+
+    Results are cached in-process for 300s. Mutations in this package that
+    can change the current user's group membership (add/remove_tenant_member,
+    add/remove_group_member, create_tenant_and_assign_users) bust the cache.
+
+    Args:
+        force_refresh: If True, bypass the cache and hit the governance API.
 
     Returns:
         UserGroupsResponse with username, groups list, and group_count
     """
+    if not force_refresh:
+        cached = groups_cache.get(_GROUPS_CACHE_KEY)
+        if cached is not None:
+            return cached
+
     client = get_governance_client()
     response = get_my_groups_workspaces_me_groups_get.sync(client=client)
 
@@ -308,6 +323,7 @@ def get_my_groups() -> UserGroupsResponse:
     if not isinstance(response, UserGroupsResponse):
         raise RuntimeError("Failed to get groups: no response from API")
 
+    groups_cache.set(_GROUPS_CACHE_KEY, response)
     return response
 
 
@@ -660,6 +676,7 @@ def add_group_member(
             username=username,
         )
         results.append((username, response))
+    invalidate_all()
     return results
 
 
@@ -705,6 +722,7 @@ def remove_group_member(
             username=username,
         )
         results.append((username, response))
+    invalidate_all()
     return results
 
 
@@ -775,6 +793,7 @@ def create_tenant_and_assign_users(
                 result["add_members"].append((username, error_response))
                 # Continue with other users even if one fails
 
+    invalidate_all()
     return result
 
 

--- a/notebook_utils/berdl_notebook_utils/minio_governance/tenant_management.py
+++ b/notebook_utils/berdl_notebook_utils/minio_governance/tenant_management.py
@@ -34,8 +34,11 @@ from governance_client.models import (
 from governance_client.types import UNSET
 
 from ..clients import get_governance_client
+from ._cache import invalidate_all, tenants_cache
 
 logger = logging.getLogger(__name__)
+
+_TENANTS_CACHE_KEY = "all"
 
 
 def _error_message(response: ErrorResponse) -> str:
@@ -60,12 +63,19 @@ _PERMISSION_MAP = {
 }
 
 
-def list_tenants() -> list[TenantSummaryResponse]:
+def list_tenants(force_refresh: bool = False) -> list[TenantSummaryResponse]:
     """
     List all tenants with summary info.
 
     Returns a list of tenants with member count, and whether the current user
     is a member or steward of each tenant.
+
+    Results are cached in-process for 300s. Any tenant mutation in this
+    package (add/remove member, assign/remove steward, update metadata,
+    create_tenant_and_assign_users, add/remove_group_member) busts the cache.
+
+    Args:
+        force_refresh: If True, bypass the cache and hit the governance API.
 
     Returns:
         List of TenantSummaryResponse objects
@@ -75,6 +85,11 @@ def list_tenants() -> list[TenantSummaryResponse]:
         for t in tenants:
             print(f"{t.tenant_name} - {t.member_count} members")
     """
+    if not force_refresh:
+        cached = tenants_cache.get(_TENANTS_CACHE_KEY)
+        if cached is not None:
+            return cached
+
     client = get_governance_client()
     response = list_tenants_tenants_get.sync(client=client)
 
@@ -84,6 +99,7 @@ def list_tenants() -> list[TenantSummaryResponse]:
     if not isinstance(response, list):
         raise RuntimeError("Failed to list tenants: no response from API")
 
+    tenants_cache.set(_TENANTS_CACHE_KEY, response)
     return response
 
 
@@ -237,6 +253,7 @@ def add_tenant_member(
     if not isinstance(response, TenantMemberResponse):
         raise RuntimeError(f"Failed to add member {username!r}: no response from API")
 
+    invalidate_all()
     logger.info(f"Added {username} to tenant {tenant_name} with {permission} access")
     return response
 
@@ -266,6 +283,7 @@ def remove_tenant_member(tenant_name: str, username: str) -> None:
             f"Failed to remove member {username!r} from tenant {tenant_name!r}: {_error_message(response)}"
         )
 
+    invalidate_all()
     logger.info(f"Removed {username} from tenant {tenant_name}")
 
 
@@ -320,6 +338,7 @@ def update_tenant_metadata(
     if not isinstance(response, TenantMetadataResponse):
         raise RuntimeError("Failed to update tenant metadata: no response from API")
 
+    invalidate_all()
     logger.info(f"Updated metadata for tenant {tenant_name}")
     return response
 
@@ -357,6 +376,7 @@ def assign_steward(tenant_name: str, username: str) -> TenantStewardResponse:
     if not isinstance(response, TenantStewardResponse):
         raise RuntimeError(f"Failed to assign steward {username!r}: no response from API")
 
+    invalidate_all()
     logger.info(f"Assigned {username} as steward of tenant {tenant_name}")
     return response
 
@@ -386,6 +406,7 @@ def remove_steward(tenant_name: str, username: str) -> None:
             f"Failed to remove steward {username!r} from tenant {tenant_name!r}: {_error_message(response)}"
         )
 
+    invalidate_all()
     logger.info(f"Removed {username} as steward of tenant {tenant_name}")
 
 

--- a/notebook_utils/berdl_notebook_utils/minio_governance/tenant_management.py
+++ b/notebook_utils/berdl_notebook_utils/minio_governance/tenant_management.py
@@ -70,7 +70,7 @@ def list_tenants(force_refresh: bool = False) -> list[TenantSummaryResponse]:
     Returns a list of tenants with member count, and whether the current user
     is a member or steward of each tenant.
 
-    Results are cached in-process for 300s. Any tenant mutation in this
+    Results are cached in-process for 3600s. Any tenant mutation in this
     package (add/remove member, assign/remove steward, update metadata,
     create_tenant_and_assign_users, add/remove_group_member) busts the cache.
 

--- a/notebook_utils/berdl_notebook_utils/spark/connect_server.py
+++ b/notebook_utils/berdl_notebook_utils/spark/connect_server.py
@@ -144,7 +144,7 @@ class SparkConnectServerConfig:
 
         # Writable tenant prefixes — exclude read-only groups (ending in "ro")
         try:
-            groups_response = get_my_groups()
+            groups_response = get_my_groups(force_refresh=True)
             for group in groups_response.groups:
                 if not group.endswith("ro"):
                     # Tenant prefix format: "{group}_" (matches generate_group_governance_prefix)

--- a/notebook_utils/berdl_notebook_utils/spark/data_store.py
+++ b/notebook_utils/berdl_notebook_utils/spark/data_store.py
@@ -67,8 +67,13 @@ def _ttl_cache(ttl_seconds: int = _CACHE_TTL_SECONDS) -> Callable:
 
 @_ttl_cache()
 def _cached_get_my_groups():
-    """Cached wrapper for get_my_groups()."""
-    return get_my_groups()
+    """Cached wrapper for get_my_groups().
+
+    Uses force_refresh=True to bypass the library-level 1-hour cache so
+    that this wrapper's own 300s TTL controls freshness for data-store
+    callers (namespace viewers, database listings, etc.).
+    """
+    return get_my_groups(force_refresh=True)
 
 
 @_ttl_cache()

--- a/notebook_utils/berdl_notebook_utils/spark/data_store.py
+++ b/notebook_utils/berdl_notebook_utils/spark/data_store.py
@@ -14,6 +14,7 @@ from pyspark.sql import SparkSession
 
 from .. import hive_metastore
 from ..minio_governance import get_my_accessible_paths, get_my_groups, get_namespace_prefix
+from ..minio_governance._cache import invalidate_all as _invalidate_governance_cache
 from ..setup_spark_session import get_spark_session
 
 # =============================================================================
@@ -90,6 +91,7 @@ def _cached_get_my_accessible_paths():
 
 def clear_governance_cache() -> None:
     """Clear all governance API caches. Call this when user permissions change."""
+    _invalidate_governance_cache()
     getattr(_cached_get_my_groups, "clear_cache", lambda: None)()
     getattr(_cached_get_namespace_prefix, "clear_cache", lambda: None)()
     getattr(_cached_get_my_accessible_paths, "clear_cache", lambda: None)()

--- a/notebook_utils/pyproject.toml
+++ b/notebook_utils/pyproject.toml
@@ -9,6 +9,7 @@ dependencies = [
     "httpx>=0.24",
     "pydantic-settings>=2.0",
     "attrs>=25.4.0",
+    "cacheout==0.16.0",
     # Spark
     "pyspark[connect]>=4.0",
     # Storage / Hive

--- a/notebook_utils/tests/conftest.py
+++ b/notebook_utils/tests/conftest.py
@@ -2,6 +2,8 @@
 
 import os
 
+import pytest
+
 
 TEST_ENVIRONMENT = {
     "USER": "fake_user",
@@ -22,6 +24,16 @@ TEST_ENVIRONMENT = {
 
 for key, value in TEST_ENVIRONMENT.items():
     os.environ.setdefault(key, value)
+
+
+@pytest.fixture(autouse=True)
+def _clear_governance_caches():
+    """Clear in-process governance caches between tests to avoid test pollution."""
+    from berdl_notebook_utils.minio_governance._cache import invalidate_all
+
+    invalidate_all()
+    yield
+    invalidate_all()
 
 
 class WarehouseResponse:

--- a/notebook_utils/tests/minio_governance/test_operations.py
+++ b/notebook_utils/tests/minio_governance/test_operations.py
@@ -405,6 +405,35 @@ class TestGetMyGroups:
         with pytest.raises(RuntimeError, match="no response from API"):
             get_my_groups()
 
+    @patch("berdl_notebook_utils.minio_governance.operations.get_governance_client")
+    @patch("berdl_notebook_utils.minio_governance.operations.get_my_groups_workspaces_me_groups_get")
+    def test_cache_hit_skips_api(self, mock_get_groups, mock_get_client):
+        """Second call returns cached result without hitting the API again."""
+        mock_get_client.return_value = Mock()
+        mock_get_groups.sync.return_value = Mock(spec=UserGroupsResponse, groups=["g1"])
+
+        result1 = get_my_groups()
+        result2 = get_my_groups()
+
+        assert result1 is result2
+        mock_get_groups.sync.assert_called_once()
+
+    @patch("berdl_notebook_utils.minio_governance.operations.get_governance_client")
+    @patch("berdl_notebook_utils.minio_governance.operations.get_my_groups_workspaces_me_groups_get")
+    def test_force_refresh_bypasses_cache(self, mock_get_groups, mock_get_client):
+        """force_refresh=True always hits the API."""
+        mock_get_client.return_value = Mock()
+        first = Mock(spec=UserGroupsResponse, groups=["g1"])
+        second = Mock(spec=UserGroupsResponse, groups=["g1", "g2"])
+        mock_get_groups.sync.side_effect = [first, second]
+
+        result1 = get_my_groups()
+        result2 = get_my_groups(force_refresh=True)
+
+        assert result1.groups == ["g1"]
+        assert result2.groups == ["g1", "g2"]
+        assert mock_get_groups.sync.call_count == 2
+
 
 class TestGetMyAccessiblePaths:
     """Tests for get_my_accessible_paths function."""

--- a/notebook_utils/tests/minio_governance/test_tenant_management.py
+++ b/notebook_utils/tests/minio_governance/test_tenant_management.py
@@ -69,6 +69,36 @@ class TestListTenants:
         with pytest.raises(RuntimeError, match="no response"):
             list_tenants()
 
+    @patch(f"{MODULE}.get_governance_client")
+    @patch(f"{MODULE}.list_tenants_tenants_get")
+    def test_cache_hit_skips_api(self, mock_api, mock_client):
+        """Second call returns cached result without hitting the API again."""
+        mock_client.return_value = Mock()
+        summary = Mock(spec=TenantSummaryResponse)
+        mock_api.sync.return_value = [summary]
+
+        result1 = list_tenants()
+        result2 = list_tenants()
+
+        assert result1 == result2 == [summary]
+        mock_api.sync.assert_called_once()
+
+    @patch(f"{MODULE}.get_governance_client")
+    @patch(f"{MODULE}.list_tenants_tenants_get")
+    def test_force_refresh_bypasses_cache(self, mock_api, mock_client):
+        """force_refresh=True always hits the API."""
+        mock_client.return_value = Mock()
+        first = Mock(spec=TenantSummaryResponse)
+        second = Mock(spec=TenantSummaryResponse)
+        mock_api.sync.side_effect = [[first], [second]]
+
+        result1 = list_tenants()
+        result2 = list_tenants(force_refresh=True)
+
+        assert result1 == [first]
+        assert result2 == [second]
+        assert mock_api.sync.call_count == 2
+
 
 # =============================================================================
 # get_my_steward_tenants

--- a/notebook_utils/uv.lock
+++ b/notebook_utils/uv.lock
@@ -206,6 +206,7 @@ version = "0.0.1"
 source = { virtual = "." }
 dependencies = [
     { name = "attrs" },
+    { name = "cacheout" },
     { name = "cdm-spark-manager-client" },
     { name = "cdm-task-service-client" },
     { name = "datalake-mcp-server-client" },
@@ -238,6 +239,7 @@ dev = [
 [package.metadata]
 requires-dist = [
     { name = "attrs", specifier = ">=25.4.0" },
+    { name = "cacheout", specifier = "==0.16.0" },
     { name = "cdm-spark-manager-client", git = "https://github.com/kbase/cdm-kube-spark-manager-client.git?rev=0.0.1" },
     { name = "cdm-task-service-client", git = "https://github.com/kbase/cdm-task-service-client?rev=0.2.3" },
     { name = "datalake-mcp-server-client", git = "https://github.com/BERDataLakehouse/datalake-mcp-server-client.git?rev=v0.0.9" },
@@ -265,6 +267,15 @@ dev = [
     { name = "pytest-cov", specifier = ">=4.1.0" },
     { name = "pytest-env", specifier = ">=1.2.0" },
     { name = "ruff", specifier = "==0.14.4" },
+]
+
+[[package]]
+name = "cacheout"
+version = "0.16.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/d1/60/ed4c4b27b2131a0b2cc461789be2cf06866644ca462cb34a5d8fca114c15/cacheout-0.16.0.tar.gz", hash = "sha256:ee264897cbaa089ae5f406da11952697d99fa7f3583cfab69fe8a00ff8e1952d", size = 42050, upload-time = "2023-12-22T17:44:33.29Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/72/14/a89bb55107b8a9b586c8878f47d0b7750c3688c209f05f915e70de74880d/cacheout-0.16.0-py3-none-any.whl", hash = "sha256:1a52d9aa8b1e9720d8453b061348f15795578231f9ec4ad376fec49e717d0ed8", size = 21837, upload-time = "2023-12-22T17:44:31.556Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary

Adds caching to `list_tenants()` and `get_my_groups()` — the two governance API calls the tenants landing page hits on every load. As tenant count grows these round-trips slow down the page.

## Changes

| File | Change |
|---|---|
| `_cache.py` | **New** — two `Cache(maxsize=1, ttl=3600)` instances + `invalidate_all()` |
| `tenant_management.py` | `list_tenants(force_refresh=False)` reads/writes cache; mutations call `invalidate_all()` |
| `operations.py` | `get_my_groups(force_refresh=False)` reads/writes cache; mutations call `invalidate_all()` |
| `pyproject.toml` | Added `cacheout==0.16.0` (matches minio_manager_service & tenant_access_request_service) |
| `conftest.py` | `autouse` fixture clears caches between tests |
| `Dockerfile` | `BASE_TAG` → `pr-156` (base image adds cacheout + patch bumps) |

## Design

- **1-hour TTL** — tenant list and group memberships rarely change mid-session
- **`cacheout.Cache`** — same library/pattern used in `minio_manager_service` (KBase profile client) and `tenant_access_request_service` (KBase auth). Thread-safe.
- **Invalidation on mutation** — `invalidate_all()` called after every write operation so the admin/steward sees their own change immediately. Other users' pods see it after TTL expires (same staleness window as `trino_access_control`'s 300s cache)
- **Manual bypass** — `list_tenants(force_refresh=True)` / `get_my_groups(force_refresh=True)`
- **Not a security boundary** — this cache only affects the landing page UI badges. Actual access enforcement is in MinIO IAM / Trino plugin.

## Depends on

- https://github.com/BERDataLakehouse/spark_notebook_base/pull/156 (adds `cacheout==0.16.0` to base image)