### PR TITLE
CDM-543: Add detailed=True option to get_table_schema

### DIFF
--- a/notebook_utils/berdl_notebook_utils/spark/data_store.py
+++ b/notebook_utils/berdl_notebook_utils/spark/data_store.py
@@ -278,8 +278,8 @@ def get_tables(
 
 
 def get_table_schema(
-    database: str, table: str, spark: Optional[SparkSession] = None, return_json: bool = True
-) -> Union[str, List[str]]:
+    database: str, table: str, spark: Optional[SparkSession] = None, return_json: bool = True, detailed: bool = False
+) -> Union[str, List[str], List[Dict[str, Any]]]:
     """
     Get the schema of a specific table in a database.
 
@@ -288,14 +288,20 @@ def get_table_schema(
         table: Name of the table
         spark: Optional SparkSession to use
         return_json: Whether to return JSON string or raw data
+        detailed: If True, return each column as a dict of all
+            pyspark.sql.catalog.Column fields instead of just its name
 
     Returns:
-        List of column names, either as JSON string or raw list
+        List of column names, or list of column metadata dicts when detailed=True,
+        either as JSON string or raw list
     """
 
-    def _get_schema(session: SparkSession, db: str, tbl: str) -> List[str]:
+    def _get_schema(session: SparkSession, db: str, tbl: str) -> Union[List[str], List[Dict[str, Any]]]:
         try:
-            return [column.name for column in session.catalog.listColumns(dbName=db, tableName=tbl)]
+            cols = session.catalog.listColumns(dbName=db, tableName=tbl)
+            if detailed:
+                return [c._asdict() for c in cols]
+            return [c.name for c in cols]
         except Exception:
             # Observed that certain tables lack their corresponding S3 files
             print(f"Error retrieving schema for table {tbl} in database {db}")

--- a/notebook_utils/tests/spark/test_data_store.py
+++ b/notebook_utils/tests/spark/test_data_store.py
@@ -430,6 +430,22 @@ class TestGetTableSchemaErrorPath:
         assert result == []
 
 
+class TestGetTableSchemaDetailed:
+    """Tests for get_table_schema detailed=True branch."""
+
+    def test_detailed_returns_column_dicts(self):
+        """Test detailed=True returns each column's _asdict()."""
+        mock_spark = Mock()
+        col1, col2 = Mock(), Mock()
+        col1._asdict.return_value = {"name": "id"}
+        col2._asdict.return_value = {"name": "name"}
+        mock_spark.catalog.listColumns.return_value = [col1, col2]
+
+        result = get_table_schema("test_db", "t", spark=mock_spark, return_json=False, detailed=True)
+
+        assert result == [{"name": "id"}, {"name": "name"}]
+
+
 class TestGetDbStructureSparkPath:
     """Tests for get_db_structure with use_hms=False (Spark inner function)."""
 


### PR DESCRIPTION
## Summary
- Additive `detailed=False` kwarg on `get_table_schema` returning each column as a dict of all `pyspark.sql.catalog.Column` fields when set.
- Default behavior unchanged; existing callers (`get_db_structure`, tests, MCP path) still get `List[str]` of column names.
- Consumed by tenant-data-browser to populate data-type and comment cells in the Data Dictionary view (CDM-543).

## Test plan
- [x] `pytest tests/spark/test_data_store.py` — 33 passed