### PR TITLE
Refresh notebook auth caches

### DIFF
--- a/configs/ipython_startup/05-token-sync.py
+++ b/configs/ipython_startup/05-token-sync.py
@@ -11,26 +11,20 @@ invalidated so they rebuild with the fresh token on next use.
 """
 
 import logging
-import os
 import threading
 import time
-from pathlib import Path
 
-from berdl_notebook_utils.cache import clear_kbase_token_caches
+from berdl_notebook_utils.cache import sync_kbase_token_from_cache_file
 
 logger = logging.getLogger(__name__)
 
-TOKEN_CACHE_FILE = ".berdl_kbase_session"
 TOKEN_SYNC_INTERVAL_SECONDS = 30
 
 
 def _sync_token():
     """Read token from session file and update env var if changed."""
     try:
-        token = (Path.home() / TOKEN_CACHE_FILE).read_text().strip()
-        if token and token != os.environ.get("KBASE_AUTH_TOKEN", ""):
-            os.environ["KBASE_AUTH_TOKEN"] = token
-            clear_kbase_token_caches()
+        if sync_kbase_token_from_cache_file():
             logger.info("Kernel token updated from session file")
     except Exception:
         logger.debug("Token sync skipped: session file not available")

--- a/notebook_utils/berdl_notebook_utils/berdl_settings.py
+++ b/notebook_utils/berdl_notebook_utils/berdl_settings.py
@@ -8,7 +8,7 @@ from functools import lru_cache
 from pydantic import AnyHttpUrl, AnyUrl, Field, ValidationError
 from pydantic_settings import BaseSettings
 
-from berdl_notebook_utils.cache import kbase_token_dependent
+from berdl_notebook_utils.cache import kbase_token_dependent, sync_kbase_token_before_call
 
 # Configure logging
 logger = logging.getLogger(__name__)
@@ -105,6 +105,7 @@ def validate_environment():
         return [error["loc"][0] for error in e.errors()]
 
 
+@sync_kbase_token_before_call
 @kbase_token_dependent
 @lru_cache(maxsize=1)
 def get_settings() -> BERDLSettings:

--- a/notebook_utils/berdl_notebook_utils/cache.py
+++ b/notebook_utils/berdl_notebook_utils/cache.py
@@ -5,6 +5,17 @@ Provides a decorator for registering lru_cache'd functions that should be
 invalidated when the KBase auth token changes.
 """
 
+import os
+from collections.abc import Callable
+from functools import wraps
+from pathlib import Path
+import sys
+from typing import TypeVar
+
+TOKEN_CACHE_FILE = ".berdl_kbase_session"
+
+F = TypeVar("F", bound=Callable)
+
 _token_change_caches = []
 
 
@@ -18,3 +29,57 @@ def clear_kbase_token_caches():
     """Clear all registered token-dependent caches."""
     for cached in _token_change_caches:
         cached.cache_clear()
+
+
+def _get_token_cache_path() -> Path:
+    return Path.home() / TOKEN_CACHE_FILE
+
+
+def _clear_loaded_governance_caches() -> None:
+    module = sys.modules.get("berdl_notebook_utils.minio_governance._cache")
+    if module is None:
+        return
+
+    invalidate_all = getattr(module, "invalidate_all", None)
+    if callable(invalidate_all):
+        invalidate_all()
+
+
+def clear_berdl_token_caches() -> None:
+    """Clear all token-dependent BERDL caches in this process."""
+    clear_kbase_token_caches()
+    _clear_loaded_governance_caches()
+
+
+def sync_kbase_token_from_cache_file(path: Path | None = None) -> bool:
+    """Sync KBASE_AUTH_TOKEN from ~/.berdl_kbase_session when it changed.
+
+    Returns True when the process environment was updated.
+    """
+    token_path = path if path is not None else _get_token_cache_path()
+    try:
+        token = token_path.read_text().strip()
+    except OSError:
+        return False
+
+    if not token or token == os.environ.get("KBASE_AUTH_TOKEN", ""):
+        return False
+
+    os.environ["KBASE_AUTH_TOKEN"] = token
+    clear_berdl_token_caches()
+    return True
+
+
+def sync_kbase_token_before_call(func: F) -> F:
+    """Decorator that refreshes the process token before cache lookup/use."""
+
+    @wraps(func)
+    def wrapper(*args, **kwargs):
+        sync_kbase_token_from_cache_file()
+        return func(*args, **kwargs)
+
+    for attr in ("cache_clear", "cache_info", "cache_parameters"):
+        if hasattr(func, attr):
+            setattr(wrapper, attr, getattr(func, attr))
+
+    return wrapper

--- a/notebook_utils/berdl_notebook_utils/clients.py
+++ b/notebook_utils/berdl_notebook_utils/clients.py
@@ -8,9 +8,10 @@ from minio import Minio
 from spark_manager_client.client import AuthenticatedClient as SparkAuthenticatedClient
 
 from berdl_notebook_utils import BERDLSettings, get_settings
-from berdl_notebook_utils.cache import kbase_token_dependent
+from berdl_notebook_utils.cache import kbase_token_dependent, sync_kbase_token_before_call
 
 
+@sync_kbase_token_before_call
 @kbase_token_dependent
 @lru_cache(maxsize=1)
 def get_task_service_client(settings: BERDLSettings | None = None) -> CTSClient:
@@ -44,6 +45,7 @@ def get_minio_client(settings: BERDLSettings | None = None) -> Minio:
     )
 
 
+@sync_kbase_token_before_call
 @kbase_token_dependent
 @lru_cache(maxsize=1)
 def get_governance_client(
@@ -64,6 +66,7 @@ def get_governance_client(
     )
 
 
+@sync_kbase_token_before_call
 @kbase_token_dependent
 @lru_cache(maxsize=1)
 def get_spark_cluster_client(

--- a/notebook_utils/berdl_notebook_utils/mcp/client.py
+++ b/notebook_utils/berdl_notebook_utils/mcp/client.py
@@ -12,7 +12,7 @@ import httpx
 from datalake_mcp_server_client.client import AuthenticatedClient
 
 from berdl_notebook_utils.berdl_settings import get_settings
-from berdl_notebook_utils.cache import kbase_token_dependent
+from berdl_notebook_utils.cache import kbase_token_dependent, sync_kbase_token_before_call
 
 logger = logging.getLogger(__name__)
 
@@ -20,6 +20,7 @@ logger = logging.getLogger(__name__)
 DEFAULT_TIMEOUT = 300.0
 
 
+@sync_kbase_token_before_call
 @kbase_token_dependent
 @lru_cache(maxsize=1)
 def get_datalake_mcp_client() -> AuthenticatedClient:

--- a/notebook_utils/tests/test_cache.py
+++ b/notebook_utils/tests/test_cache.py
@@ -1,11 +1,17 @@
 """Tests for cache.py - Token-dependent cache management."""
 
 from functools import lru_cache
+import os
+import sys
+from types import SimpleNamespace
 
 from berdl_notebook_utils.cache import (
     _token_change_caches,
+    clear_berdl_token_caches,
     clear_kbase_token_caches,
     kbase_token_dependent,
+    sync_kbase_token_before_call,
+    sync_kbase_token_from_cache_file,
 )
 
 
@@ -118,3 +124,111 @@ class TestClearKbaseTokenCaches:
         finally:
             _token_change_caches.remove(func_a)
             _token_change_caches.remove(func_b)
+
+
+class TestClearBerdlTokenCaches:
+    """Tests for clearing all BERDL token-dependent caches."""
+
+    def test_clears_token_and_loaded_governance_caches(self, monkeypatch):
+        calls: list[str] = []
+
+        @lru_cache
+        def cached_func():
+            return "value"
+
+        _token_change_caches.append(cached_func)
+        monkeypatch.setitem(
+            sys.modules,
+            "berdl_notebook_utils.minio_governance._cache",
+            SimpleNamespace(invalidate_all=lambda: calls.append("governance")),
+        )
+
+        try:
+            cached_func()
+            cached_func()
+            assert cached_func.cache_info().hits == 1
+
+            clear_berdl_token_caches()
+
+            assert cached_func.cache_info().hits == 0
+            assert calls == ["governance"]
+        finally:
+            _token_change_caches.remove(cached_func)
+
+
+class TestSyncKbaseTokenFromCacheFile:
+    """Tests for syncing KBase token from the server-written cache file."""
+
+    def test_updates_env_and_clears_token_caches(self, tmp_path, monkeypatch):
+        call_count = 0
+
+        @lru_cache
+        def cached_func():
+            nonlocal call_count
+            call_count += 1
+            return call_count
+
+        _token_change_caches.append(cached_func)
+        token_file = tmp_path / ".berdl_kbase_session"
+        token_file.write_text("new-token")
+        monkeypatch.setenv("KBASE_AUTH_TOKEN", "old-token")
+
+        try:
+            assert cached_func() == 1
+            assert cached_func() == 1
+
+            assert sync_kbase_token_from_cache_file(token_file) is True
+
+            assert os.environ["KBASE_AUTH_TOKEN"] == "new-token"
+            assert cached_func() == 2
+        finally:
+            _token_change_caches.remove(cached_func)
+
+    def test_clears_loaded_governance_caches(self, tmp_path, monkeypatch):
+        calls: list[str] = []
+        token_file = tmp_path / ".berdl_kbase_session"
+        token_file.write_text("new-token")
+        monkeypatch.setenv("KBASE_AUTH_TOKEN", "old-token")
+        monkeypatch.setitem(
+            sys.modules,
+            "berdl_notebook_utils.minio_governance._cache",
+            SimpleNamespace(invalidate_all=lambda: calls.append("governance")),
+        )
+
+        assert sync_kbase_token_from_cache_file(token_file) is True
+
+        assert calls == ["governance"]
+
+    def test_noops_when_token_is_unchanged(self, tmp_path, monkeypatch):
+        token_file = tmp_path / ".berdl_kbase_session"
+        token_file.write_text("same-token")
+        monkeypatch.setenv("KBASE_AUTH_TOKEN", "same-token")
+
+        assert sync_kbase_token_from_cache_file(token_file) is False
+
+    def test_noops_when_token_file_is_missing(self, tmp_path):
+        assert sync_kbase_token_from_cache_file(tmp_path / "missing") is False
+
+
+class TestSyncKbaseTokenBeforeCall:
+    """Tests for the pre-call token sync decorator."""
+
+    def test_runs_sync_before_lru_cache_lookup(self, tmp_path, monkeypatch):
+        calls: list[str] = []
+        token_file = tmp_path / ".berdl_kbase_session"
+        token_file.write_text("fresh-token")
+        monkeypatch.setenv("KBASE_AUTH_TOKEN", "old-token")
+        monkeypatch.setattr(
+            "berdl_notebook_utils.cache._get_token_cache_path",
+            lambda: token_file,
+        )
+
+        @sync_kbase_token_before_call
+        @lru_cache
+        def cached_func():
+            calls.append(os.environ["KBASE_AUTH_TOKEN"])
+            return os.environ["KBASE_AUTH_TOKEN"]
+
+        assert cached_func() == "fresh-token"
+        assert cached_func() == "fresh-token"
+        assert calls == ["fresh-token"]

--- a/notebook_utils/tests/test_clients_extended.py
+++ b/notebook_utils/tests/test_clients_extended.py
@@ -6,7 +6,7 @@ from unittest.mock import Mock, patch
 
 import pytest
 
-from berdl_notebook_utils.berdl_settings import BERDLSettings
+from berdl_notebook_utils.berdl_settings import BERDLSettings, get_settings
 from berdl_notebook_utils.clients import (
     get_task_service_client,
     get_minio_client,
@@ -24,6 +24,7 @@ def clear_caches():
     get_governance_client.cache_clear()
     get_spark_cluster_client.cache_clear()
     get_hive_metastore_client.cache_clear()
+    get_settings.cache_clear()
     yield
 
 
@@ -92,6 +93,31 @@ class TestGetGovernanceClient:
             # URL may have trailing slash added by httpx/AuthenticatedClient
             assert call_kwargs["base_url"].rstrip("/") == "http://localhost:8000"
             assert call_kwargs["token"] == "test-token-123"
+
+    def test_get_governance_client_refreshes_token_before_cache_lookup(self, tmp_path, monkeypatch):
+        """Test that cached governance client is rebuilt after token cache changes."""
+        token_file = tmp_path / ".berdl_kbase_session"
+        monkeypatch.setattr(
+            "berdl_notebook_utils.cache._get_token_cache_path",
+            lambda: token_file,
+        )
+        monkeypatch.setenv("KBASE_AUTH_TOKEN", "old-token")
+        token_file.write_text("old-token")
+
+        with patch("berdl_notebook_utils.clients.GovernanceAuthenticatedClient") as mock_client_class:
+            old_client = Mock(name="old_client")
+            new_client = Mock(name="new_client")
+            mock_client_class.side_effect = [old_client, new_client]
+
+            client1 = get_governance_client()
+
+            token_file.write_text("new-token")
+            client2 = get_governance_client()
+
+            assert client1 is old_client
+            assert client2 is new_client
+            assert mock_client_class.call_args_list[0][1]["token"] == "old-token"
+            assert mock_client_class.call_args_list[1][1]["token"] == "new-token"
 
 
 class TestGetSparkClusterClient:


### PR DESCRIPTION
Refresh notebook auth state from the token cache before using cached BERDL clients.