### PR TITLE
fix(hms): deprecated get_hive_metastore_client() must return an unope…

### DIFF
--- a/notebook_utils/berdl_notebook_utils/clients.py
+++ b/notebook_utils/berdl_notebook_utils/clients.py
@@ -149,8 +149,9 @@ def get_hive_metastore_client(
         stacklevel=2,
     )
     pool = get_hive_metastore_pool(settings)
-    # Build a fresh client through the pool's factory so socket-level
-    # timeouts still apply, but bypass the pool itself: the caller owns
-    # the connection's full lifecycle.
+    # Return a fresh, UNOPENED client built through the pool's factory.
+    # The legacy contract was: caller does open()/.../close(). We preserve
+    # that contract while still applying socket_timeout_ms so legacy callers
+    # also get wedge-protection.
     # Disable lint of private call: documented escape hatch for legacy callers.
-    return pool._new_client()  # type: ignore[attr-defined]  # noqa: SLF001
+    return pool._build_client()  # type: ignore[attr-defined]  # noqa: SLF001

--- a/notebook_utils/berdl_notebook_utils/hms_pool.py
+++ b/notebook_utils/berdl_notebook_utils/hms_pool.py
@@ -147,14 +147,27 @@ class HMSClientPool:
     # Internals
     # ------------------------------------------------------------------
 
-    def _new_client(self) -> HMSClient:
+    def _build_client(self) -> HMSClient:
+        """Construct a configured but **unopened** ``HMSClient``.
+
+        The transport carries the pool's socket-level connect+read timeout
+        (``socket_timeout_ms``) so that even callers who use this client
+        outside the pool — e.g. the deprecated
+        :func:`berdl_notebook_utils.clients.get_hive_metastore_client` — get
+        the same wedge-protection. The caller is responsible for ``open()``
+        and ``close()``.
+        """
         sock = TSocket.TSocket(self._host, self._port)
         # Applies to both connect() and recv() at the socket layer. Without
         # this, a wedged peer can block a worker thread forever.
         sock.setTimeout(self._socket_timeout_ms)
         transport = TTransport.TBufferedTransport(sock)
         protocol = TBinaryProtocol.TBinaryProtocol(transport)
-        client = HMSClient(iprot=protocol)
+        return HMSClient(iprot=protocol)
+
+    def _new_client(self) -> HMSClient:
+        """Construct, open, and account for a new pool-owned ``HMSClient``."""
+        client = self._build_client()
         client.open()
         with self._metrics_lock:
             self._created += 1

--- a/notebook_utils/tests/test_clients_extended.py
+++ b/notebook_utils/tests/test_clients_extended.py
@@ -170,11 +170,33 @@ class TestDeprecatedGetHiveMetastoreClient:
     def test_emits_deprecation_warning(self):
         with patch.object(
             type(get_hive_metastore_pool()),
-            "_new_client",
+            "_build_client",
             return_value=Mock(),
         ):
             with pytest.warns(DeprecationWarning, match="thread-safe"):
                 get_hive_metastore_client()
+
+    def test_returns_unopened_client(self):
+        """Regression: the deprecated factory MUST return an unopened client
+        because the pre-fix legacy contract is ``client.open() / ... /
+        client.close()``. Returning an already-open client breaks every
+        legacy caller with ``TTransportException: already open``.
+        """
+        with pytest.warns(DeprecationWarning):
+            client = get_hive_metastore_client()
+        try:
+            # Underlying TSocket has no handle yet → not connected.
+            # If this assertion fails the legacy ``client.open()`` call sites
+            # will raise ``TTransportException: already open``.
+            assert client._oprot.trans.isOpen() is False, (  # noqa: SLF001
+                "deprecated get_hive_metastore_client() must return an "
+                "unopened client; legacy callers do client.open() themselves"
+            )
+        finally:
+            try:
+                client.close()
+            except Exception:  # noqa: BLE001
+                pass
 
 
 class TestClientWithCustomSettings:


### PR DESCRIPTION
…ned client