### PR TITLE
Add central TTL cache registry; rename cache.py -> kbase_token_cache.py

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-ARG BASE_TAG=pr-157
+ARG BASE_TAG=pr-160
 ARG BASE_REGISTRY=ghcr.io/berdatalakehouse/
 FROM ${BASE_REGISTRY}spark_notebook_base:${BASE_TAG}
 

--- a/configs/ipython_startup/05-token-sync.py
+++ b/configs/ipython_startup/05-token-sync.py
@@ -14,7 +14,7 @@ import logging
 import threading
 import time
 
-from berdl_notebook_utils.cache import sync_kbase_token_from_cache_file
+from berdl_notebook_utils.kbase_token_cache import sync_kbase_token_from_cache_file
 
 logger = logging.getLogger(__name__)
 

--- a/configs/ipython_startup/06-kbase-user-profile.py
+++ b/configs/ipython_startup/06-kbase-user-profile.py
@@ -1,0 +1,31 @@
+"""
+Sync KBase user-profile fields into the kernel environment.
+==========================================================
+
+Runs once at kernel startup. Calls KBase auth ``/api/V2/me`` and exports
+identity fields that are useful to user notebooks but not provided by the
+spawner:
+
+* ``ORCID`` — the user's linked ORCID identifier, when present.
+
+Best-effort: missing token / auth URL or transient HTTP errors are logged
+and the script exits cleanly without raising.
+"""
+
+import logging
+
+from berdl_notebook_utils.berdl_settings import get_settings
+from berdl_notebook_utils.kbase_user import sync_orcid_to_env
+
+logger = logging.getLogger("berdl.startup")
+
+try:
+    orcid = sync_orcid_to_env()
+    if orcid:
+        # Drop any cached settings so subsequent get_settings() reflects ORCID
+        get_settings.cache_clear()
+        logger.info(f"✅ ORCID={orcid}")
+    else:
+        logger.info("ℹ️  ORCID not set (no linked ORCID identity or auth not configured)")
+except Exception as e:
+    logger.warning(f"Failed to sync KBase user profile: {e}")

--- a/configs/jupyter_server_config.py
+++ b/configs/jupyter_server_config.py
@@ -10,6 +10,8 @@ from hybridcontents import HybridContentsManager
 from jupyter_server.services.contents.largefilemanager import LargeFileManager
 from grouped_s3_contents import GroupedS3ContentsManager
 
+from berdl_notebook_utils.kbase_user import sync_orcid_to_env
+
 # Configure logging
 logging.basicConfig(level=logging.INFO)
 logger = logging.getLogger("berdl.jupyter_config")
@@ -134,6 +136,23 @@ def get_user_governance_paths():
     return sources
 
 
+def provision_kbase_user_profile():
+    """Sync KBase user-profile fields (currently ORCID) to the server env.
+
+    Called once at Jupyter Server startup so values like ORCID are inherited
+    by all kernels spawned from this server. Failures are logged and
+    swallowed — they must not prevent the server from starting.
+    """
+    try:
+        orcid = sync_orcid_to_env()
+        if orcid:
+            logger.info(f"ORCID provisioned for current user: {orcid}")
+        else:
+            logger.info("ORCID not set (no linked ORCID or KBASE_AUTH_URL not configured)")
+    except Exception as e:
+        logger.warning(f"Failed to sync KBase user profile: {e}")
+
+
 def start_spark_connect():
     """Start Spark Connect server at Jupyter Server startup.
 
@@ -165,10 +184,13 @@ username = os.environ.get("NB_USER", "jovyan")
 endpoint_url, access_key, secret_key, use_ssl = get_minio_config()
 governance_paths = get_user_governance_paths()
 
-# 3. Start Spark Connect server in background (non-blocking)
+# 3. Provision KBase user-profile fields (ORCID) so spawned kernels inherit them
+provision_kbase_user_profile()
+
+# 4. Start Spark Connect server in background (non-blocking)
 start_spark_connect()
 
-# 4. Configure HybridContentsManager
+# 5. Configure HybridContentsManager
 # - Root ("") -> Local filesystem
 # - "datalake_minio" -> GroupedS3ContentsManager with all S3 paths as subdirectories
 c.HybridContentsManager.manager_classes = {

--- a/notebook_utils/berdl_notebook_utils/__init__.py
+++ b/notebook_utils/berdl_notebook_utils/__init__.py
@@ -214,22 +214,12 @@ def berdl_notebook_help():
     - update_tenant_metadata: Update tenant display name, description, org
     - show_my_tenants: Display all your tenants (admins see all tenants)
 
-    MCP Server Operations (via Global Datalake MCP Server):
-    -------------------------------------------------------
-    - mcp_list_databases: List all databases via MCP server
-    - mcp_list_tables: List tables in a database via MCP server
-    - mcp_get_table_schema: Get table schema via MCP server
-    - mcp_get_database_structure: Get complete database structure via MCP server
-    - mcp_count_table: Count rows in a table via MCP server
-    - mcp_sample_table: Sample data from a table via MCP server
-    - mcp_query_table: Execute SQL queries via MCP server
-    - mcp_select_table: Execute structured SELECT queries with filters, joins, aggregations
-
-    BERDL Agent (AI Assistant):
-    ---------------------------
-    - create_berdl_agent: Create an AI agent for natural language data lake interactions
-    - BERDLAgent: Agent class for advanced configuration
-    - AgentSettings: Agent configuration settings
+    Data Store Operations:
+    ---------------------
+    - get_databases: List all accessible databases
+    - get_tables: List tables in a database
+    - get_table_schema: Get column schema for a table
+    - get_db_structure: Get full {database: [tables]} structure (optionally with schemas)
 
     Environment Refresh:
     -------------------
@@ -243,25 +233,15 @@ def berdl_notebook_help():
     # Create Spark session
     spark = get_spark_session("MyAnalysis")
 
-    # Read and display data
-    df = spark.read.csv("s3a://your-bucket/data.csv")
-    display_df(df)
+    # Browse the data store
+    from berdl_notebook_utils import get_databases, get_tables, get_table_schema
 
-    # Share table with colleagues
-    share_table("analytics", "user_metrics", with_users=["alice", "bob"])
+    databases = get_databases()
+    tables = get_tables("my_db")
+    schema = get_table_schema("my_db", "my_table")
 
-    # Use MCP server for queries
-    from berdl_notebook_utils import mcp_list_databases, mcp_query_table
-
-    databases = mcp_list_databases()
-    results = mcp_query_table("SELECT * FROM my_db.my_table LIMIT 10")
-
-    # Use AI Agent for natural language queries
-    from berdl_notebook_utils import create_berdl_agent
-
-    agent = create_berdl_agent()
-    result = agent.run("What databases do I have access to?")
-    result = agent.run("Show me the top 10 rows from my_db.user_activity")
+    # Run SQL queries through Spark
+    results = spark.sql("SELECT * FROM my_db.my_table LIMIT 10").toPandas()
 
     For detailed documentation, see the README.md or individual module docstrings.
     """

--- a/notebook_utils/berdl_notebook_utils/berdl_settings.py
+++ b/notebook_utils/berdl_notebook_utils/berdl_settings.py
@@ -21,6 +21,16 @@ class BERDLSettings(BaseSettings):
 
     # Core authentication
     KBASE_AUTH_TOKEN: str
+    KBASE_AUTH_URL: AnyHttpUrl | None = Field(
+        default=None,
+        description="KBase Auth service base URL (e.g. https://ci.kbase.us/services/auth/). "
+        "When set, /api/V2/me is queried at startup to populate ORCID.",
+    )
+    ORCID: str | None = Field(
+        default=None,
+        description="ORCID identifier for the current user, populated from /api/V2/me at startup "
+        "when the KBase account is linked to ORCID.",
+    )
     CDM_TASK_SERVICE_URL: AnyHttpUrl  # Accepts http:// and https://
     USER: str  # KBase username of the user running the notebook
 

--- a/notebook_utils/berdl_notebook_utils/berdl_settings.py
+++ b/notebook_utils/berdl_notebook_utils/berdl_settings.py
@@ -8,7 +8,7 @@ from functools import lru_cache
 from pydantic import AnyHttpUrl, AnyUrl, Field, ValidationError
 from pydantic_settings import BaseSettings
 
-from berdl_notebook_utils.cache import kbase_token_dependent, sync_kbase_token_before_call
+from berdl_notebook_utils.kbase_token_cache import kbase_token_dependent, sync_kbase_token_before_call
 
 # Configure logging
 logger = logging.getLogger(__name__)

--- a/notebook_utils/berdl_notebook_utils/caches.py
+++ b/notebook_utils/berdl_notebook_utils/caches.py
@@ -1,0 +1,175 @@
+"""Central registry of in-process TTL caches used across berdl_notebook_utils.
+
+Each domain module owns its :class:`cacheout.Cache` instance (so the TTL,
+size, and eviction pressure are tuned per workload), but registers it here
+so callers have ONE place to:
+
+* discover every cache and what it stores (:func:`list_caches`)
+* clear one cache by name (:func:`clear_cache`)
+* clear all caches or a domain prefix (:func:`clear_all_caches`)
+
+This is intentionally separate from
+:mod:`berdl_notebook_utils.kbase_token_cache`, which manages
+``@lru_cache``'d *client/factory singletons* and their token-rotation
+invalidation. The two caching layers serve different purposes:
+
+* ``kbase_token_cache``: object pools (clients, settings) — invalidated
+  when the KBase auth token changes.
+* ``caches`` (this module): TTL data caches (groups, tenants, databases,
+  tables, schemas) — invalidated by TTL or explicit ``force_refresh``.
+
+The token rotation hook in ``kbase_token_cache.clear_berdl_token_caches``
+also calls :func:`clear_all_caches` here, so token changes wipe both
+layers.
+
+Usage
+-----
+
+In a domain module:
+
+    from ..caches import register_cache
+
+    groups_cache = register_cache(
+        "minio_governance.groups",
+        maxsize=1, ttl_seconds=3600,
+        description="Cached get_my_groups() UserGroupsResponse.",
+    )
+
+In any caller (notebook, tests, handlers):
+
+    from berdl_notebook_utils.caches import list_caches, clear_all_caches
+
+    list_caches()              # → [{name, ttl_seconds, size, maxsize, description}, ...]
+    clear_all_caches()         # nuclear: wipe everything
+    clear_all_caches(prefix="spark.data_store.")  # targeted wipe
+"""
+
+from dataclasses import dataclass
+from threading import RLock
+from typing import Any, Optional
+
+from cacheout import Cache
+
+
+@dataclass
+class CacheInfo:
+    """Metadata wrapper around a registered :class:`cacheout.Cache`."""
+
+    name: str
+    cache: Cache
+    ttl_seconds: int
+    description: str
+
+    def stats(self) -> dict[str, Any]:
+        """Return a JSON-serializable snapshot of this cache's state."""
+        return {
+            "name": self.name,
+            "ttl_seconds": self.ttl_seconds,
+            "description": self.description,
+            "size": len(self.cache),
+            "maxsize": self.cache.maxsize,
+        }
+
+
+_registry: dict[str, CacheInfo] = {}
+_lock = RLock()
+
+
+def register_cache(
+    name: str,
+    *,
+    maxsize: int,
+    ttl_seconds: int,
+    description: str,
+) -> Cache:
+    """Create and register a new TTL :class:`cacheout.Cache`, or return the existing one.
+
+    Idempotent by ``name`` so repeated module imports (e.g. in test
+    reloads) do not produce duplicate caches.
+
+    Args:
+        name: Globally unique cache identifier. Convention:
+            ``"<module>.<purpose>"`` — e.g. ``"spark.data_store.tables"``.
+            Use a stable prefix per domain so :func:`clear_all_caches`
+            with ``prefix=`` works for targeted wipes.
+        maxsize: Max number of entries before LRU eviction.
+        ttl_seconds: Time-to-live for each entry, in seconds.
+        description: Human-readable summary of what's cached. Surfaced by
+            :func:`list_caches` for discoverability.
+
+    Returns:
+        The registered :class:`cacheout.Cache`. Callers store this in
+        their module and use it directly.
+
+    Raises:
+        ValueError: If ``name`` is already registered with different
+            settings (size or TTL). Re-registering with identical
+            settings returns the existing cache.
+    """
+    with _lock:
+        existing = _registry.get(name)
+        if existing is not None:
+            if existing.ttl_seconds != ttl_seconds or existing.cache.maxsize != maxsize:
+                raise ValueError(
+                    f"Cache {name!r} already registered with different settings: "
+                    f"existing(maxsize={existing.cache.maxsize}, ttl={existing.ttl_seconds}) "
+                    f"vs new(maxsize={maxsize}, ttl={ttl_seconds})"
+                )
+            return existing.cache
+
+        cache: Cache = Cache(maxsize=maxsize, ttl=ttl_seconds)
+        _registry[name] = CacheInfo(
+            name=name,
+            cache=cache,
+            ttl_seconds=ttl_seconds,
+            description=description,
+        )
+        return cache
+
+
+def list_caches() -> list[dict[str, Any]]:
+    """Return stats for every registered cache, sorted by name."""
+    with _lock:
+        return [info.stats() for info in sorted(_registry.values(), key=lambda i: i.name)]
+
+
+def get_cache(name: str) -> Optional[Cache]:
+    """Return the registered cache by name, or ``None`` if unknown."""
+    with _lock:
+        info = _registry.get(name)
+        return info.cache if info is not None else None
+
+
+def clear_cache(name: str) -> bool:
+    """Clear one cache by name. Returns True if found and cleared, False otherwise."""
+    with _lock:
+        info = _registry.get(name)
+        if info is None:
+            return False
+        info.cache.clear()
+        return True
+
+
+def clear_all_caches(prefix: Optional[str] = None) -> int:
+    """Clear all registered caches, optionally filtered by name prefix.
+
+    Args:
+        prefix: If given, only clear caches whose name starts with this
+            string (e.g. ``"spark.data_store."``).
+
+    Returns:
+        Number of caches cleared.
+    """
+    cleared = 0
+    with _lock:
+        for name, info in _registry.items():
+            if prefix is None or name.startswith(prefix):
+                info.cache.clear()
+                cleared += 1
+    return cleared
+
+
+def _reset_registry_for_tests() -> None:
+    """Drop all registered caches. Test-only — do NOT call from production code."""
+    with _lock:
+        _registry.clear()

--- a/notebook_utils/berdl_notebook_utils/clients.py
+++ b/notebook_utils/berdl_notebook_utils/clients.py
@@ -8,7 +8,7 @@ from minio import Minio
 from spark_manager_client.client import AuthenticatedClient as SparkAuthenticatedClient
 
 from berdl_notebook_utils import BERDLSettings, get_settings
-from berdl_notebook_utils.cache import kbase_token_dependent, sync_kbase_token_before_call
+from berdl_notebook_utils.kbase_token_cache import kbase_token_dependent, sync_kbase_token_before_call
 from berdl_notebook_utils.hms_pool import HMSClientPool, build_pool_from_settings
 
 

--- a/notebook_utils/berdl_notebook_utils/kbase_token_cache.py
+++ b/notebook_utils/berdl_notebook_utils/kbase_token_cache.py
@@ -1,16 +1,33 @@
-"""
-Token-dependent cache management.
+"""KBase auth token cache management.
 
-Provides a decorator for registering lru_cache'd functions that should be
-invalidated when the KBase auth token changes.
+Manages two related concerns tied to KBase auth tokens:
+
+1. Registry of ``@lru_cache``'d functions whose results depend on the
+   current KBase token (e.g. authenticated client factories) — see
+   :func:`kbase_token_dependent`. These are wiped via
+   :func:`clear_kbase_token_caches` when the token rotates.
+
+2. The token-sync watcher that picks up token changes from
+   ``~/.berdl_kbase_session`` and pushes them into ``os.environ``, then
+   triggers cache invalidation — see
+   :func:`sync_kbase_token_from_cache_file`.
+
+Token rotation also wipes all TTL caches registered in
+:mod:`berdl_notebook_utils.caches` (groups, tenants, table schemas, etc.)
+because their contents may have been computed with the prior token.
+
+This module was previously named ``cache.py``; it was renamed to
+``kbase_token_cache`` to clearly distinguish it from the general TTL
+cache registry in :mod:`berdl_notebook_utils.caches`.
 """
 
 import os
-import sys
 from collections.abc import Callable
 from functools import wraps
 from pathlib import Path
 from typing import TypeVar
+
+from .caches import clear_all_caches as _clear_all_ttl_caches
 
 TOKEN_CACHE_FILE = ".berdl_kbase_session"
 
@@ -37,20 +54,19 @@ def _get_token_cache_path() -> Path:
     return Path.home() / TOKEN_CACHE_FILE
 
 
-def _clear_loaded_governance_caches() -> None:
-    module = sys.modules.get("berdl_notebook_utils.minio_governance._cache")
-    if module is None:
-        return
-
-    invalidate_all = getattr(module, "invalidate_all", None)
-    if callable(invalidate_all):
-        invalidate_all()
-
-
 def clear_berdl_token_caches() -> None:
-    """Clear all token-dependent BERDL caches in this process."""
+    """Clear all in-process BERDL caches in response to a token change.
+
+    Wipes both:
+
+    * ``@lru_cache``'d client/factory functions registered via
+      :func:`kbase_token_dependent`, and
+    * every TTL cache registered in :mod:`berdl_notebook_utils.caches`
+      (governance, data_store, etc.) whose content may have been computed
+      with the prior token.
+    """
     clear_kbase_token_caches()
-    _clear_loaded_governance_caches()
+    _clear_all_ttl_caches()
 
 
 def sync_kbase_token_from_cache_file(path: Path | None = None) -> bool:

--- a/notebook_utils/berdl_notebook_utils/kbase_user.py
+++ b/notebook_utils/berdl_notebook_utils/kbase_user.py
@@ -1,0 +1,117 @@
+"""KBase auth user-profile helpers.
+
+Fetches user-profile data from the KBase auth service ``/api/V2/me`` endpoint
+and surfaces commonly-needed fields (e.g. the user's ORCID identifier) into
+the kernel/process environment so notebooks can read them via ``os.environ``.
+
+ORCID is exported as ``ORCID`` when the user has linked their KBase account
+to ORCID. Calling this module is best-effort: any HTTP / parse error is
+logged and the env var is left unchanged.
+"""
+
+from __future__ import annotations
+
+import logging
+import os
+from typing import Any
+
+import httpx
+
+logger = logging.getLogger(__name__)
+
+#: Environment variable name set by :func:`sync_orcid_to_env`.
+ORCID_ENV_VAR = "ORCID"
+
+#: ``provider`` value used by the KBase auth service for ORCID-linked identities.
+ORCID_PROVIDER = "OrcID"
+
+#: Default HTTP timeout for /api/V2/me calls.
+_DEFAULT_TIMEOUT_SECONDS = 10.0
+
+
+def fetch_user_profile(
+    auth_url: str,
+    token: str,
+    *,
+    timeout: float = _DEFAULT_TIMEOUT_SECONDS,
+) -> dict[str, Any]:
+    """Fetch ``/api/V2/me`` from a KBase auth service.
+
+    Args:
+        auth_url: KBase auth base URL (e.g. ``https://ci.kbase.us/services/auth/``).
+            Trailing slash is optional.
+        token: KBase auth token (sent as the ``Authorization`` header value).
+        timeout: HTTP timeout in seconds.
+
+    Returns:
+        Parsed JSON response. The shape includes keys like ``user``, ``display``,
+        ``email``, ``customroles`` and ``idents`` (a list of linked identity
+        provider entries).
+
+    Raises:
+        httpx.HTTPError: On network failure or non-2xx response.
+    """
+    url = f"{auth_url.rstrip('/')}/api/V2/me"
+    response = httpx.get(
+        url,
+        headers={"Authorization": token},
+        timeout=timeout,
+    )
+    response.raise_for_status()
+    return response.json()
+
+
+def extract_orcid(profile: dict[str, Any]) -> str | None:
+    """Return the user's ORCID identifier from a profile dict, or ``None``.
+
+    Looks for an entry in ``profile["idents"]`` whose ``provider`` equals
+    :data:`ORCID_PROVIDER` and returns its ``provusername`` (the bare ORCID id
+    in the form ``XXXX-XXXX-XXXX-XXXX``).
+    """
+    for ident in profile.get("idents") or []:
+        if ident.get("provider") == ORCID_PROVIDER:
+            orcid = ident.get("provusername")
+            if orcid:
+                return str(orcid)
+    return None
+
+
+def sync_orcid_to_env(
+    auth_url: str | None = None,
+    token: str | None = None,
+) -> str | None:
+    """Fetch the current user's ORCID and export it as ``ORCID``.
+
+    Best-effort: any HTTP / parse error is logged at WARNING level and ``None``
+    is returned; the env var is unchanged. When the user has no linked ORCID
+    identity, ``None`` is also returned (and the env var is unchanged).
+
+    Args:
+        auth_url: KBase auth base URL. Defaults to ``$KBASE_AUTH_URL``.
+        token: KBase auth token. Defaults to ``$KBASE_AUTH_TOKEN``.
+
+    Returns:
+        The ORCID identifier when found and exported, otherwise ``None``.
+    """
+    auth_url = auth_url or os.environ.get("KBASE_AUTH_URL")
+    token = token or os.environ.get("KBASE_AUTH_TOKEN")
+    if not auth_url or not token:
+        logger.debug(
+            "Skipping ORCID sync: KBASE_AUTH_URL and KBASE_AUTH_TOKEN must both be set"
+        )
+        return None
+
+    try:
+        profile = fetch_user_profile(auth_url, token)
+    except Exception as exc:
+        logger.warning("Failed to fetch KBase user profile from %s: %s", auth_url, exc)
+        return None
+
+    orcid = extract_orcid(profile)
+    user = profile.get("user", "<unknown>")
+    if orcid:
+        os.environ[ORCID_ENV_VAR] = orcid
+        logger.info("Set %s=%s for user %s", ORCID_ENV_VAR, orcid, user)
+    else:
+        logger.info("User %s has no linked ORCID identity; %s not set", user, ORCID_ENV_VAR)
+    return orcid

--- a/notebook_utils/berdl_notebook_utils/kbase_user.py
+++ b/notebook_utils/berdl_notebook_utils/kbase_user.py
@@ -96,9 +96,7 @@ def sync_orcid_to_env(
     auth_url = auth_url or os.environ.get("KBASE_AUTH_URL")
     token = token or os.environ.get("KBASE_AUTH_TOKEN")
     if not auth_url or not token:
-        logger.debug(
-            "Skipping ORCID sync: KBASE_AUTH_URL and KBASE_AUTH_TOKEN must both be set"
-        )
+        logger.debug("Skipping ORCID sync: KBASE_AUTH_URL and KBASE_AUTH_TOKEN must both be set")
         return None
 
     try:

--- a/notebook_utils/berdl_notebook_utils/mcp/client.py
+++ b/notebook_utils/berdl_notebook_utils/mcp/client.py
@@ -12,7 +12,7 @@ import httpx
 from datalake_mcp_server_client.client import AuthenticatedClient
 
 from berdl_notebook_utils.berdl_settings import get_settings
-from berdl_notebook_utils.cache import kbase_token_dependent, sync_kbase_token_before_call
+from berdl_notebook_utils.kbase_token_cache import kbase_token_dependent, sync_kbase_token_before_call
 
 logger = logging.getLogger(__name__)
 

--- a/notebook_utils/berdl_notebook_utils/minio_governance/_cache.py
+++ b/notebook_utils/berdl_notebook_utils/minio_governance/_cache.py
@@ -4,18 +4,33 @@ The extension's tenants landing page hits list_tenants() and get_my_groups()
 on every load, which scales with tenant count. These caches use a 1-hour
 TTL to reduce repeated read traffic while keeping staleness bounded.
 
-Mutations in this package call invalidate_all() after success so changes
-made in the same notebook process are reflected on the next read.
+Mutations in this package call :func:`invalidate_all` after success so
+changes made in the same notebook process are reflected on the next read.
+
+The cache instances are owned by this module but registered in the central
+:mod:`berdl_notebook_utils.caches` registry so they can be discovered and
+wiped uniformly with all other BERDL TTL caches.
 """
 
-from cacheout import Cache
+from ..caches import clear_all_caches, register_cache
 
 _TTL_SECONDS = 3600
+_NAME_PREFIX = "minio_governance."
 
-tenants_cache: Cache = Cache(maxsize=1, ttl=_TTL_SECONDS)
-groups_cache: Cache = Cache(maxsize=1, ttl=_TTL_SECONDS)
+tenants_cache = register_cache(
+    f"{_NAME_PREFIX}tenants",
+    maxsize=1,
+    ttl_seconds=_TTL_SECONDS,
+    description="list_tenants(): cached TenantSummaryResponse list for the current user.",
+)
+groups_cache = register_cache(
+    f"{_NAME_PREFIX}groups",
+    maxsize=1,
+    ttl_seconds=_TTL_SECONDS,
+    description="get_my_groups(): cached UserGroupsResponse for the current user.",
+)
 
 
 def invalidate_all() -> None:
-    tenants_cache.clear()
-    groups_cache.clear()
+    """Clear all governance caches (tenants + groups)."""
+    clear_all_caches(prefix=_NAME_PREFIX)

--- a/notebook_utils/tests/test_caches.py
+++ b/notebook_utils/tests/test_caches.py
@@ -1,0 +1,128 @@
+"""Tests for berdl_notebook_utils.caches — the central TTL cache registry."""
+
+import pytest
+
+from berdl_notebook_utils import caches
+
+
+@pytest.fixture(autouse=True)
+def _isolate_registry():
+    """Snapshot/restore the central registry around each test for isolation."""
+    original = dict(caches._registry)
+    yield
+    caches._registry.clear()
+    caches._registry.update(original)
+
+
+class TestRegisterCache:
+    """Tests for register_cache()."""
+
+    def test_creates_and_registers_new_cache(self):
+        cache = caches.register_cache("test.alpha", maxsize=8, ttl_seconds=30, description="alpha test")
+        cache.set("k", "v")
+
+        assert cache.get("k") == "v"
+        assert "test.alpha" in {info["name"] for info in caches.list_caches()}
+
+    def test_idempotent_when_settings_match(self):
+        first = caches.register_cache("test.alpha", maxsize=8, ttl_seconds=30, description="alpha")
+        second = caches.register_cache("test.alpha", maxsize=8, ttl_seconds=30, description="alpha (re-import)")
+
+        assert first is second  # same Cache instance returned
+
+    def test_raises_when_settings_differ(self):
+        caches.register_cache("test.alpha", maxsize=8, ttl_seconds=30, description="alpha")
+        with pytest.raises(ValueError, match="different settings"):
+            caches.register_cache("test.alpha", maxsize=16, ttl_seconds=30, description="conflict")
+
+        with pytest.raises(ValueError, match="different settings"):
+            caches.register_cache("test.alpha", maxsize=8, ttl_seconds=60, description="conflict")
+
+
+class TestListCaches:
+    """Tests for list_caches() reporting."""
+
+    def test_returns_stats_for_all_registered(self):
+        c1 = caches.register_cache("test.beta", maxsize=4, ttl_seconds=10, description="beta")
+        c1.set("a", 1)
+        c1.set("b", 2)
+        caches.register_cache("test.alpha", maxsize=2, ttl_seconds=5, description="alpha")
+
+        stats = caches.list_caches()
+        # Sorted by name → alpha first, then beta
+        names = [s["name"] for s in stats if s["name"].startswith("test.")]
+        assert names == ["test.alpha", "test.beta"]
+
+        beta = next(s for s in stats if s["name"] == "test.beta")
+        assert beta["size"] == 2
+        assert beta["maxsize"] == 4
+        assert beta["ttl_seconds"] == 10
+        assert beta["description"] == "beta"
+
+
+class TestClearCache:
+    """Tests for clear_cache() (single-cache invalidation)."""
+
+    def test_clears_named_cache(self):
+        cache = caches.register_cache("test.gamma", maxsize=4, ttl_seconds=30, description="g")
+        cache.set("k", "v")
+
+        assert caches.clear_cache("test.gamma") is True
+        assert cache.get("k") is None
+
+    def test_returns_false_when_unknown(self):
+        assert caches.clear_cache("test.does_not_exist") is False
+
+
+class TestClearAllCaches:
+    """Tests for clear_all_caches() global / prefix-scoped invalidation."""
+
+    def test_clears_everything_when_no_prefix(self):
+        c1 = caches.register_cache("test.one", maxsize=4, ttl_seconds=30, description="1")
+        c2 = caches.register_cache("test.two", maxsize=4, ttl_seconds=30, description="2")
+        c1.set("a", 1)
+        c2.set("b", 2)
+
+        cleared = caches.clear_all_caches()
+
+        assert cleared >= 2  # may include caches registered by other modules at import
+        assert c1.get("a") is None
+        assert c2.get("b") is None
+
+    def test_prefix_only_clears_matching(self):
+        keep = caches.register_cache("other.module", maxsize=4, ttl_seconds=30, description="keep")
+        wipe = caches.register_cache("test.scoped.x", maxsize=4, ttl_seconds=30, description="wipe x")
+        wipe2 = caches.register_cache("test.scoped.y", maxsize=4, ttl_seconds=30, description="wipe y")
+        keep.set("k", "v")
+        wipe.set("k", "v")
+        wipe2.set("k", "v")
+
+        cleared = caches.clear_all_caches(prefix="test.scoped.")
+
+        assert cleared == 2
+        assert keep.get("k") == "v"
+        assert wipe.get("k") is None
+        assert wipe2.get("k") is None
+
+
+class TestGetCache:
+    """Tests for get_cache() lookup."""
+
+    def test_returns_registered_cache(self):
+        cache = caches.register_cache("test.delta", maxsize=4, ttl_seconds=30, description="d")
+        assert caches.get_cache("test.delta") is cache
+
+    def test_returns_none_when_unknown(self):
+        assert caches.get_cache("test.nope") is None
+
+
+class TestRegistryIntegration:
+    """Verify production modules pre-register their caches at import time."""
+
+    def test_minio_governance_caches_are_registered(self):
+        # Import triggers registration as a side effect.
+        from berdl_notebook_utils.minio_governance import _cache  # noqa: F401
+
+        names = {info["name"] for info in caches.list_caches()}
+        assert "minio_governance.tenants" in names
+        assert "minio_governance.groups" in names

--- a/notebook_utils/tests/test_clients_extended.py
+++ b/notebook_utils/tests/test_clients_extended.py
@@ -100,7 +100,7 @@ class TestGetGovernanceClient:
         """Test that cached governance client is rebuilt after token cache changes."""
         token_file = tmp_path / ".berdl_kbase_session"
         monkeypatch.setattr(
-            "berdl_notebook_utils.cache._get_token_cache_path",
+            "berdl_notebook_utils.kbase_token_cache._get_token_cache_path",
             lambda: token_file,
         )
         monkeypatch.setenv("KBASE_AUTH_TOKEN", "old-token")

--- a/notebook_utils/tests/test_kbase_token_cache.py
+++ b/notebook_utils/tests/test_kbase_token_cache.py
@@ -1,13 +1,12 @@
-"""Tests for cache.py - Token-dependent cache management."""
+"""Tests for kbase_token_cache.py - Token-dependent cache management."""
 
 from functools import lru_cache
 import os
 from pathlib import Path
-import sys
-from types import SimpleNamespace
 
-import berdl_notebook_utils.cache as cache_module
-from berdl_notebook_utils.cache import (
+import berdl_notebook_utils.kbase_token_cache as cache_module
+from berdl_notebook_utils import caches as central_caches
+from berdl_notebook_utils.kbase_token_cache import (
     _token_change_caches,
     clear_berdl_token_caches,
     clear_kbase_token_caches,
@@ -131,31 +130,38 @@ class TestClearKbaseTokenCaches:
 class TestClearBerdlTokenCaches:
     """Tests for clearing all BERDL token-dependent caches."""
 
-    def test_clears_token_and_loaded_governance_caches(self, monkeypatch):
-        calls: list[str] = []
+    def test_clears_lru_caches_and_central_registry(self):
+        """clear_berdl_token_caches() must wipe both lru_cache'd functions
+        and every TTL cache registered via berdl_notebook_utils.caches."""
+        ttl_cache = central_caches.register_cache(
+            "test_kbase_token_cache.token_clear",
+            maxsize=4,
+            ttl_seconds=60,
+            description="Throwaway cache used by clear_berdl_token_caches test.",
+        )
+        ttl_cache.set("key", "value")
 
         @lru_cache
         def cached_func():
             return "value"
 
         _token_change_caches.append(cached_func)
-        monkeypatch.setitem(
-            sys.modules,
-            "berdl_notebook_utils.minio_governance._cache",
-            SimpleNamespace(invalidate_all=lambda: calls.append("governance")),
-        )
 
         try:
             cached_func()
             cached_func()
             assert cached_func.cache_info().hits == 1
+            assert ttl_cache.get("key") == "value"
 
             clear_berdl_token_caches()
 
             assert cached_func.cache_info().hits == 0
-            assert calls == ["governance"]
+            assert ttl_cache.get("key") is None
         finally:
             _token_change_caches.remove(cached_func)
+            central_caches.clear_cache("test_kbase_token_cache.token_clear")
+            # Drop the throwaway registration so it doesn't leak across tests.
+            central_caches._registry.pop("test_kbase_token_cache.token_clear", None)
 
 
 class TestSyncKbaseTokenFromCacheFile:
@@ -186,20 +192,26 @@ class TestSyncKbaseTokenFromCacheFile:
         finally:
             _token_change_caches.remove(cached_func)
 
-    def test_clears_loaded_governance_caches(self, tmp_path, monkeypatch):
-        calls: list[str] = []
+    def test_clears_central_registry_caches(self, tmp_path, monkeypatch):
+        """A token change must wipe every cache registered in the central registry."""
+        ttl_cache = central_caches.register_cache(
+            "test_kbase_token_cache.sync_clear",
+            maxsize=4,
+            ttl_seconds=60,
+            description="Throwaway cache used by sync_kbase_token_from_cache_file test.",
+        )
+        ttl_cache.set("key", "value")
+
         token_file = tmp_path / ".berdl_kbase_session"
         token_file.write_text("new-token")
         monkeypatch.setenv("KBASE_AUTH_TOKEN", "old-token")
-        monkeypatch.setitem(
-            sys.modules,
-            "berdl_notebook_utils.minio_governance._cache",
-            SimpleNamespace(invalidate_all=lambda: calls.append("governance")),
-        )
 
-        assert sync_kbase_token_from_cache_file(token_file) is True
-
-        assert calls == ["governance"]
+        try:
+            assert sync_kbase_token_from_cache_file(token_file) is True
+            assert ttl_cache.get("key") is None
+        finally:
+            central_caches.clear_cache("test_kbase_token_cache.sync_clear")
+            central_caches._registry.pop("test_kbase_token_cache.sync_clear", None)
 
     def test_noops_when_token_is_unchanged(self, tmp_path, monkeypatch):
         token_file = tmp_path / ".berdl_kbase_session"
@@ -262,7 +274,7 @@ class TestSyncKbaseTokenBeforeCall:
         token_file.write_text("fresh-token")
         monkeypatch.setenv("KBASE_AUTH_TOKEN", "old-token")
         monkeypatch.setattr(
-            "berdl_notebook_utils.cache._get_token_cache_path",
+            "berdl_notebook_utils.kbase_token_cache._get_token_cache_path",
             lambda: token_file,
         )
 
@@ -282,7 +294,7 @@ class TestSyncKbaseTokenBeforeCall:
         token_file.write_text("first-token")
         monkeypatch.setenv("KBASE_AUTH_TOKEN", "old-token")
         monkeypatch.setattr(
-            "berdl_notebook_utils.cache._get_token_cache_path",
+            "berdl_notebook_utils.kbase_token_cache._get_token_cache_path",
             lambda: token_file,
         )
 

--- a/notebook_utils/tests/test_kbase_user.py
+++ b/notebook_utils/tests/test_kbase_user.py
@@ -74,16 +74,11 @@ class TestExtractOrcid:
         assert extract_orcid({"user": "x", "idents": None}) is None
 
     def test_returns_none_when_orcid_provusername_missing(self):
-        assert (
-            extract_orcid({"idents": [{"provider": "OrcID"}]}) is None
-        )
+        assert extract_orcid({"idents": [{"provider": "OrcID"}]}) is None
 
     def test_provider_match_is_case_sensitive(self):
         # KBase auth uses literal "OrcID" — we do not normalize.
-        assert (
-            extract_orcid({"idents": [{"provider": "orcid", "provusername": "x"}]})
-            is None
-        )
+        assert extract_orcid({"idents": [{"provider": "orcid", "provusername": "x"}]}) is None
 
     def test_returns_first_orcid_when_multiple(self):
         profile = {
@@ -116,9 +111,7 @@ class TestFetchUserProfile:
             return _response(url, json=SAMPLE_PROFILE_WITH_ORCID)
 
         with patch.object(kbase_user.httpx, "get", side_effect=fake_get):
-            result = fetch_user_profile(
-                "https://ci.kbase.us/services/auth/", "TOK", timeout=5.0
-            )
+            result = fetch_user_profile("https://ci.kbase.us/services/auth/", "TOK", timeout=5.0)
 
         assert result == SAMPLE_PROFILE_WITH_ORCID
         assert captured["url"] == "https://ci.kbase.us/services/auth/api/V2/me"
@@ -155,9 +148,7 @@ class TestSyncOrcidToEnv:
     def test_sets_env_var_when_orcid_present(self, monkeypatch):
         monkeypatch.setenv("KBASE_AUTH_URL", "https://ci.kbase.us/services/auth/")
         monkeypatch.setenv("KBASE_AUTH_TOKEN", "TOK")
-        with patch.object(
-            kbase_user, "fetch_user_profile", return_value=SAMPLE_PROFILE_WITH_ORCID
-        ):
+        with patch.object(kbase_user, "fetch_user_profile", return_value=SAMPLE_PROFILE_WITH_ORCID):
             result = sync_orcid_to_env()
 
         assert result == "0009-0004-8221-7736"
@@ -168,9 +159,7 @@ class TestSyncOrcidToEnv:
     def test_returns_none_and_leaves_env_unset_when_no_orcid(self, monkeypatch):
         monkeypatch.setenv("KBASE_AUTH_URL", "https://ci.kbase.us/services/auth/")
         monkeypatch.setenv("KBASE_AUTH_TOKEN", "TOK")
-        with patch.object(
-            kbase_user, "fetch_user_profile", return_value=SAMPLE_PROFILE_WITHOUT_ORCID
-        ):
+        with patch.object(kbase_user, "fetch_user_profile", return_value=SAMPLE_PROFILE_WITHOUT_ORCID):
             result = sync_orcid_to_env()
 
         import os
@@ -214,9 +203,7 @@ class TestSyncOrcidToEnv:
     def test_explicit_args_override_env(self, monkeypatch):
         monkeypatch.setenv("KBASE_AUTH_URL", "https://wrong/")
         monkeypatch.setenv("KBASE_AUTH_TOKEN", "wrong")
-        with patch.object(
-            kbase_user, "fetch_user_profile", return_value=SAMPLE_PROFILE_WITH_ORCID
-        ) as fetch:
+        with patch.object(kbase_user, "fetch_user_profile", return_value=SAMPLE_PROFILE_WITH_ORCID) as fetch:
             sync_orcid_to_env(auth_url="https://right/", token="right")
 
         fetch.assert_called_once_with("https://right/", "right")

--- a/notebook_utils/tests/test_kbase_user.py
+++ b/notebook_utils/tests/test_kbase_user.py
@@ -1,0 +1,222 @@
+"""Tests for berdl_notebook_utils.kbase_user."""
+
+from unittest.mock import patch
+
+import httpx
+import pytest
+
+from berdl_notebook_utils import kbase_user
+from berdl_notebook_utils.kbase_user import (
+    ORCID_ENV_VAR,
+    extract_orcid,
+    fetch_user_profile,
+    sync_orcid_to_env,
+)
+
+# A representative /api/V2/me response used across tests.
+SAMPLE_PROFILE_WITH_ORCID = {
+    "user": "tgu2",
+    "display": "Tianhao Gu",
+    "email": "tgu@anl.gov",
+    "idents": [
+        {
+            "provusername": "tgu2@globusid.org",
+            "provider": "Globus",
+            "id": "0775d642c4bec0b1d7eb62cb9ca6c898",
+        },
+        {
+            "provusername": "0009-0004-8221-7736",
+            "provider": "OrcID",
+            "id": "1e7dfb1d1352cadd0e967293f9894b60",
+        },
+    ],
+}
+
+SAMPLE_PROFILE_WITHOUT_ORCID = {
+    "user": "globusonly",
+    "idents": [
+        {
+            "provusername": "globusonly@globusid.org",
+            "provider": "Globus",
+            "id": "abc",
+        },
+    ],
+}
+
+
+@pytest.fixture(autouse=True)
+def _clear_orcid_env(monkeypatch):
+    """Ensure each test starts with the ORCID env var unset."""
+    monkeypatch.delenv(ORCID_ENV_VAR, raising=False)
+    yield
+
+
+# ---------------------------------------------------------------------------
+# extract_orcid
+# ---------------------------------------------------------------------------
+
+
+class TestExtractOrcid:
+    def test_returns_orcid_when_present(self):
+        assert extract_orcid(SAMPLE_PROFILE_WITH_ORCID) == "0009-0004-8221-7736"
+
+    def test_returns_none_when_no_orcid_provider(self):
+        assert extract_orcid(SAMPLE_PROFILE_WITHOUT_ORCID) is None
+
+    def test_returns_none_when_no_idents_field(self):
+        assert extract_orcid({"user": "x"}) is None
+
+    def test_returns_none_when_idents_is_empty(self):
+        assert extract_orcid({"user": "x", "idents": []}) is None
+
+    def test_returns_none_when_idents_is_none(self):
+        # Defensive: KBase auth has been observed to return null fields.
+        assert extract_orcid({"user": "x", "idents": None}) is None
+
+    def test_returns_none_when_orcid_provusername_missing(self):
+        assert (
+            extract_orcid({"idents": [{"provider": "OrcID"}]}) is None
+        )
+
+    def test_provider_match_is_case_sensitive(self):
+        # KBase auth uses literal "OrcID" — we do not normalize.
+        assert (
+            extract_orcid({"idents": [{"provider": "orcid", "provusername": "x"}]})
+            is None
+        )
+
+    def test_returns_first_orcid_when_multiple(self):
+        profile = {
+            "idents": [
+                {"provider": "OrcID", "provusername": "0000-0001-1111-1111"},
+                {"provider": "OrcID", "provusername": "0000-0002-2222-2222"},
+            ]
+        }
+        assert extract_orcid(profile) == "0000-0001-1111-1111"
+
+
+# ---------------------------------------------------------------------------
+# fetch_user_profile
+# ---------------------------------------------------------------------------
+
+
+def _response(url: str, status: int = 200, **kwargs) -> httpx.Response:
+    """Build an httpx.Response wired to a Request so raise_for_status works."""
+    return httpx.Response(status, request=httpx.Request("GET", url), **kwargs)
+
+
+class TestFetchUserProfile:
+    def test_calls_v2_me_with_token_header(self):
+        captured = {}
+
+        def fake_get(url, headers, timeout):
+            captured["url"] = url
+            captured["headers"] = headers
+            captured["timeout"] = timeout
+            return _response(url, json=SAMPLE_PROFILE_WITH_ORCID)
+
+        with patch.object(kbase_user.httpx, "get", side_effect=fake_get):
+            result = fetch_user_profile(
+                "https://ci.kbase.us/services/auth/", "TOK", timeout=5.0
+            )
+
+        assert result == SAMPLE_PROFILE_WITH_ORCID
+        assert captured["url"] == "https://ci.kbase.us/services/auth/api/V2/me"
+        assert captured["headers"] == {"Authorization": "TOK"}
+        assert captured["timeout"] == 5.0
+
+    def test_strips_trailing_slash_on_auth_url(self):
+        captured = {}
+
+        def fake_get(url, headers, timeout):
+            captured["url"] = url
+            return _response(url, json={})
+
+        with patch.object(kbase_user.httpx, "get", side_effect=fake_get):
+            fetch_user_profile("https://example/services/auth///", "T")
+
+        assert captured["url"] == "https://example/services/auth/api/V2/me"
+
+    def test_raises_on_http_error(self):
+        def fake_get(url, headers, timeout):
+            return _response(url, status=401, text="unauthorized")
+
+        with patch.object(kbase_user.httpx, "get", side_effect=fake_get):
+            with pytest.raises(httpx.HTTPStatusError):
+                fetch_user_profile("https://example/", "BAD")
+
+
+# ---------------------------------------------------------------------------
+# sync_orcid_to_env
+# ---------------------------------------------------------------------------
+
+
+class TestSyncOrcidToEnv:
+    def test_sets_env_var_when_orcid_present(self, monkeypatch):
+        monkeypatch.setenv("KBASE_AUTH_URL", "https://ci.kbase.us/services/auth/")
+        monkeypatch.setenv("KBASE_AUTH_TOKEN", "TOK")
+        with patch.object(
+            kbase_user, "fetch_user_profile", return_value=SAMPLE_PROFILE_WITH_ORCID
+        ):
+            result = sync_orcid_to_env()
+
+        assert result == "0009-0004-8221-7736"
+        import os
+
+        assert os.environ[ORCID_ENV_VAR] == "0009-0004-8221-7736"
+
+    def test_returns_none_and_leaves_env_unset_when_no_orcid(self, monkeypatch):
+        monkeypatch.setenv("KBASE_AUTH_URL", "https://ci.kbase.us/services/auth/")
+        monkeypatch.setenv("KBASE_AUTH_TOKEN", "TOK")
+        with patch.object(
+            kbase_user, "fetch_user_profile", return_value=SAMPLE_PROFILE_WITHOUT_ORCID
+        ):
+            result = sync_orcid_to_env()
+
+        import os
+
+        assert result is None
+        assert ORCID_ENV_VAR not in os.environ
+
+    def test_noop_when_auth_url_missing(self, monkeypatch):
+        monkeypatch.delenv("KBASE_AUTH_URL", raising=False)
+        monkeypatch.setenv("KBASE_AUTH_TOKEN", "TOK")
+        with patch.object(kbase_user, "fetch_user_profile") as fetch:
+            result = sync_orcid_to_env()
+
+        assert result is None
+        fetch.assert_not_called()
+
+    def test_noop_when_token_missing(self, monkeypatch):
+        monkeypatch.setenv("KBASE_AUTH_URL", "https://example/")
+        monkeypatch.delenv("KBASE_AUTH_TOKEN", raising=False)
+        with patch.object(kbase_user, "fetch_user_profile") as fetch:
+            result = sync_orcid_to_env()
+
+        assert result is None
+        fetch.assert_not_called()
+
+    def test_swallows_http_errors(self, monkeypatch):
+        monkeypatch.setenv("KBASE_AUTH_URL", "https://example/")
+        monkeypatch.setenv("KBASE_AUTH_TOKEN", "TOK")
+        with patch.object(
+            kbase_user,
+            "fetch_user_profile",
+            side_effect=httpx.ConnectError("boom"),
+        ):
+            result = sync_orcid_to_env()
+
+        import os
+
+        assert result is None
+        assert ORCID_ENV_VAR not in os.environ
+
+    def test_explicit_args_override_env(self, monkeypatch):
+        monkeypatch.setenv("KBASE_AUTH_URL", "https://wrong/")
+        monkeypatch.setenv("KBASE_AUTH_TOKEN", "wrong")
+        with patch.object(
+            kbase_user, "fetch_user_profile", return_value=SAMPLE_PROFILE_WITH_ORCID
+        ) as fetch:
+            sync_orcid_to_env(auth_url="https://right/", token="right")
+
+        fetch.assert_called_once_with("https://right/", "right")


### PR DESCRIPTION
Introduce berdl_notebook_utils/caches.py as a single registry where every in-process TTL Cache used in the package is registered, discoverable, and invalidatable. Each domain module continues to own its Cache instance with its own appropriate TTL/maxsize.

  - caches.register_cache(name, maxsize, ttl_seconds, description)
  - caches.list_caches()           -> stats for every registered cache
  - caches.get_cache(name)
  - caches.clear_cache(name)
  - caches.clear_all_caches(prefix=None)

Rename cache.py -> kbase_token_cache.py so the name reflects what it actually does: register lru_cache'd client/factory functions for invalidation when the KBase auth token rotates. The previous name was ambiguous given the new TTL caches.

clear_berdl_token_caches() now delegates the TTL-cache wipe to caches.clear_all_caches() instead of the fragile sys.modules lookup for 'berdl_notebook_utils.minio_governance._cache'. Token rotation now invalidates every registered TTL cache (governance, and any future domain caches), fixing a latent staleness issue.

minio_governance/_cache.py now goes through register_cache() with stable names 'minio_governance.tenants' and 'minio_governance.groups' plus human-readable descriptions; invalidate_all() becomes a one-liner using clear_all_caches(prefix='minio_governance.').

Import paths updated:
  - clients.py
  - berdl_settings.py
  - mcp/client.py
  - configs/ipython_startup/05-token-sync.py
  - tests/test_clients_extended.py (mock path)

Tests:
  - tests/test_cache.py renamed to tests/test_kbase_token_cache.py with imports updated; the two tests that monkey-patched sys.modules to fake the governance cache are rewritten to register a throwaway cache via the registry and assert it gets cleared.
  - tests/test_caches.py adds 13 new tests covering registration idempotency, conflicting-settings detection, single/prefix/global clears, and the integration assertion that production modules pre-register their caches at import time.