### PR TITLE
Phase 0.1: Iceberg migration tooling + connect-server race fixes

### DIFF
--- a/configs/spark-defaults.conf.template
+++ b/configs/spark-defaults.conf.template
@@ -43,13 +43,16 @@
 # ==============================================================================
 
 # ------------------------------------------------------------------------------
-# Delta Lake Configuration (STATIC - Server-Side Only)
+# SQL Extensions and Catalog Configuration (STATIC - Server-Side Only)
 # ------------------------------------------------------------------------------
 # These SQL extensions must be loaded when the Spark server starts.
-# They initialize Delta Lake support by registering custom SparkSessionExtensions
-# and catalog implementations that handle Delta table operations.
+# Delta Lake remains the default writer (spark_catalog -> DeltaCatalog) for
+# backward compatibility. Iceberg DDL/DML syntax is enabled by loading
+# IcebergSparkSessionExtensions here; concrete Iceberg catalogs are registered
+# dynamically per-session (e.g., when Polaris is configured).
+# Sedona provides geospatial UDFs.
 
-spark.sql.extensions=io.delta.sql.DeltaSparkSessionExtension,org.apache.sedona.sql.SedonaSqlExtensions
+spark.sql.extensions=io.delta.sql.DeltaSparkSessionExtension,org.apache.iceberg.spark.extensions.IcebergSparkSessionExtensions,org.apache.sedona.sql.SedonaSqlExtensions
 spark.sql.catalog.spark_catalog=org.apache.spark.sql.delta.catalog.DeltaCatalog
 
 # Delta Lake settings

--- a/docs/iceberg_migration_guide.md
+++ b/docs/iceberg_migration_guide.md
@@ -1,0 +1,444 @@
+# Polaris Catalog Migration Guide
+
+> **Status — Read first.** This guide describes the **target Polaris workflow**.
+> The migration *script* (`scripts/migrate_delta_to_iceberg.py`) is shipped and
+> usable today against any Spark session that has an Iceberg catalog
+> registered (the Iceberg JAR is included in the BERDL base image).
+>
+> The notebook helper API shown in many examples below
+> (`create_namespace_if_not_exists(spark, "demo")` returning `"my.demo"`,
+> `my.*` / `<tenant>.*` catalog aliases, auto-provisioned Polaris OAuth2
+> credentials) **lands with the Polaris feature rollout** — it is not yet
+> available on `main`. Until then:
+>
+> - To create a namespace in an Iceberg catalog you have manually configured,
+>   use raw SQL: `spark.sql("CREATE NAMESPACE IF NOT EXISTS my_catalog.demo")`.
+> - To run the migration script, point `target_catalog=` at the catalog name
+>   you registered (e.g. via `spark.sql.catalog.<name>=org.apache.iceberg.spark.SparkCatalog`).
+> - The "After (Iceberg/Polaris)" code blocks reflect the post-Polaris API
+>   surface and are kept here so reviewers can see the end-state.
+
+## Why We Migrated
+
+KBERDL previously used **Delta Lake + Hive Metastore** with namespace isolation enforced by naming conventions — every database had to be prefixed with `u_{username}__` (personal) or `{tenant}_` (shared). This worked but had several limitations:
+
+- **Naming conventions are fragile** — isolation depends on every user following prefix rules correctly
+- **No catalog-level boundaries** — all users share the same Hive Metastore, so a misconfigured namespace could leak data
+- **Single-engine lock-in** — Delta Lake tables are only accessible through Spark with the Delta extension
+- **No time travel or schema evolution** — Delta supports these, but Hive Metastore doesn't track them natively
+
+We migrated to **Apache Polaris + Apache Iceberg**, which provides:
+
+- **Catalog-level isolation** — each user gets their own Polaris catalog (`my`), and each tenant gets a shared catalog (e.g., `kbase`). No naming prefixes needed.
+- **Multi-engine support** — Iceberg tables can be read by Spark, Trino, DuckDB, PyIceberg, and other engines
+- **Native time travel** — query any previous snapshot of your data
+- **Schema evolution** — add, rename, or drop columns without rewriting data
+- **ACID transactions** — concurrent reads and writes are safe
+
+## What Changed
+
+| Aspect | Before (Delta/Hive) | After (Polaris/Iceberg) |
+|--------|---------------------|------------------------|
+| **Metadata catalog** | Hive Metastore | Apache Polaris (Iceberg REST catalog) |
+| **Table format** | Delta Lake | Apache Iceberg |
+| **Isolation model** | Naming prefixes (`u_user__`, `tenant_`) | Separate catalogs per user/tenant |
+| **Your personal catalog** | Hive (shared, prefix-isolated) | `my` (dedicated Polaris catalog) |
+| **Tenant catalogs** | Hive (shared, prefix-isolated) | One catalog per tenant (e.g., `kbase`) |
+| **Credentials** | MinIO S3 keys only | MinIO S3 keys + Polaris OAuth2 (auto-provisioned) |
+| **Spark session** | `get_spark_session()` | `get_spark_session()` (unchanged) |
+
+> **Migration complete:** All existing Delta Lake tables have been migrated to Iceberg in Polaris. Your data is available in the new Iceberg catalogs (`my` for personal, tenant name for shared). The original Delta tables remain accessible during the dual-read period for backward compatibility, but all new tables should be created in Iceberg.
+
+## Side-by-Side Comparison
+
+### Create a Namespace
+
+The function call is **unchanged** — only the return value format differs.
+
+<table>
+<tr><th>Before (Delta/Hive)</th><th>After (Iceberg/Polaris)</th></tr>
+<tr>
+<td>
+
+```python
+spark = get_spark_session()
+
+# Personal namespace
+ns = create_namespace_if_not_exists(
+    spark, "analysis"
+)
+# Returns: "u_tgu2__analysis"
+
+# Tenant namespace
+ns = create_namespace_if_not_exists(
+    spark, "research",
+    tenant_name="kbase"
+)
+# Returns: "kbase_research"
+```
+
+</td>
+<td>
+
+```python
+spark = get_spark_session()
+
+# Personal namespace (same call)
+ns = create_namespace_if_not_exists(
+    spark, "analysis"
+)
+# Returns: "my.analysis"
+
+# Tenant namespace (same call)
+ns = create_namespace_if_not_exists(
+    spark, "research",
+    tenant_name="kbase"
+)
+# Returns: "kbase.research"
+```
+
+</td>
+</tr>
+</table>
+
+### Write a Table
+
+<table>
+<tr><th>Before (Delta/Hive)</th><th>After (Iceberg/Polaris)</th></tr>
+<tr>
+<td>
+
+```python
+ns = create_namespace_if_not_exists(
+    spark, "analysis"
+)
+# ns = "u_tgu2__analysis"
+
+df = spark.createDataFrame(data, columns)
+
+# Delta format
+df.write.format("delta").saveAsTable(
+    f"{ns}.my_table"
+)
+```
+
+</td>
+<td>
+
+```python
+ns = create_namespace_if_not_exists(
+    spark, "analysis"
+)
+# ns = "my.analysis"
+
+df = spark.createDataFrame(data, columns)
+
+# Iceberg format (via writeTo API)
+df.writeTo(f"{ns}.my_table").createOrReplace()
+
+# Or append to existing table
+df.writeTo(f"{ns}.my_table").append()
+```
+
+</td>
+</tr>
+</table>
+
+### Read a Table
+
+<table>
+<tr><th>Before (Delta/Hive)</th><th>After (Iceberg/Polaris)</th></tr>
+<tr>
+<td>
+
+```python
+# Query with prefixed namespace
+df = spark.sql("""
+    SELECT * FROM u_tgu2__analysis.my_table
+""")
+
+# Or use the variable
+df = spark.sql(
+    f"SELECT * FROM {ns}.my_table"
+)
+```
+
+</td>
+<td>
+
+```python
+# Query with catalog.namespace
+df = spark.sql("""
+    SELECT * FROM my.analysis.my_table
+""")
+
+# Or use the variable
+df = spark.sql(
+    f"SELECT * FROM {ns}.my_table"
+)
+```
+
+</td>
+</tr>
+</table>
+
+### Cross-Catalog Queries
+
+<table>
+<tr><th>Before (Delta/Hive)</th><th>After (Iceberg/Polaris)</th></tr>
+<tr>
+<td>
+
+```python
+# Everything in one Hive catalog
+# Must know the naming convention
+spark.sql("""
+    SELECT u.name, d.dept_name
+    FROM u_tgu2__analysis.users u
+    JOIN kbase_shared.depts d
+    ON u.dept_id = d.id
+""")
+```
+
+</td>
+<td>
+
+```python
+# Explicit catalog boundaries
+spark.sql("""
+    SELECT u.name, d.dept_name
+    FROM my.analysis.users u
+    JOIN kbase.shared.depts d
+    ON u.dept_id = d.id
+""")
+```
+
+</td>
+</tr>
+</table>
+
+### List Namespaces and Tables
+
+<table>
+<tr><th>Before (Delta/Hive)</th><th>After (Iceberg/Polaris)</th></tr>
+<tr>
+<td>
+
+```python
+# Lists all Hive databases
+# (filtered by u_{user}__ prefix)
+list_namespaces(spark)
+
+# List tables in a namespace
+list_tables(spark, "u_tgu2__analysis")
+```
+
+</td>
+<td>
+
+```python
+# List namespaces in your catalog
+spark.sql("SHOW NAMESPACES IN my")
+
+# List tables in a namespace
+spark.sql(
+    "SHOW TABLES IN my.analysis"
+)
+
+# list_tables still works
+list_tables(spark, "my.analysis")
+```
+
+</td>
+</tr>
+</table>
+
+### Drop a Table
+
+<table>
+<tr><th>Before (Delta/Hive)</th><th>After (Iceberg/Polaris)</th></tr>
+<tr>
+<td>
+
+```python
+spark.sql(
+    "DROP TABLE IF EXISTS "
+    "u_tgu2__analysis.my_table"
+)
+```
+
+</td>
+<td>
+
+```python
+spark.sql(
+    "DROP TABLE IF EXISTS "
+    "my.analysis.my_table"
+)
+```
+
+> **Note:** `DROP TABLE` removes the catalog entry but does **not** delete the underlying S3 data files. `DROP TABLE ... PURGE` also does not delete files due to a [known Iceberg bug](https://github.com/apache/iceberg/issues/14743). To fully remove data, delete files from S3 directly using `get_s3_client()`.
+
+</td>
+</tr>
+</table>
+
+## Iceberg-Only Features
+
+These features are only available with Iceberg tables.
+
+### Time Travel
+
+Query a previous version of your table:
+
+```python
+# View snapshot history
+spark.sql("SELECT * FROM my.analysis.my_table.snapshots")
+
+# Read data as it was at a specific snapshot
+spark.sql("""
+    SELECT * FROM my.analysis.my_table
+    VERSION AS OF 1234567890
+""")
+
+# Read data as it was at a specific timestamp
+spark.sql("""
+    SELECT * FROM my.analysis.my_table
+    TIMESTAMP AS OF '2026-03-01 12:00:00'
+""")
+```
+
+### Schema Evolution
+
+Modify table schema without rewriting data:
+
+```python
+# Add a column
+spark.sql("ALTER TABLE my.analysis.my_table ADD COLUMN email STRING")
+
+# Rename a column
+spark.sql("ALTER TABLE my.analysis.my_table RENAME COLUMN name TO full_name")
+
+# Drop a column
+spark.sql("ALTER TABLE my.analysis.my_table DROP COLUMN temp_field")
+```
+
+### Snapshot Management
+
+```python
+# View snapshot history
+display_df(spark.sql("SELECT * FROM my.analysis.my_table.snapshots"))
+
+# View file-level details
+display_df(spark.sql("SELECT * FROM my.analysis.my_table.files"))
+
+# View table history
+display_df(spark.sql("SELECT * FROM my.analysis.my_table.history"))
+```
+
+## Complete Example
+
+```python
+# 1. Create a Spark session
+print("1. Creating Spark session...")
+spark = get_spark_session("MyAnalysis")
+print("   Spark session ready.")
+
+# 2. Create a personal namespace
+print("\n2. Creating personal namespace...")
+ns = create_namespace_if_not_exists(spark, "demo")
+print(f"   Namespace: {ns}")  # "my.demo"
+
+# 3. Create a table
+print(f"\n3. Creating table {ns}.employees...")
+data = [(1, "Alice", 25), (2, "Bob", 30), (3, "Charlie", 35)]
+df = spark.createDataFrame(data, ["id", "name", "age"])
+df.writeTo(f"{ns}.employees").createOrReplace()
+print(f"   Table {ns}.employees created with {df.count()} rows.")
+
+# 4. Query the table
+print(f"\n4. Querying {ns}.employees:")
+result = spark.sql(f"SELECT * FROM {ns}.employees")
+display_df(result)
+
+# 5. Append more data
+print(f"\n5. Appending data to {ns}.employees...")
+new_data = [(4, "Diana", 28)]
+new_df = spark.createDataFrame(new_data, ["id", "name", "age"])
+new_df.writeTo(f"{ns}.employees").append()
+print(f"   Appended {new_df.count()} row(s). Total: {spark.sql(f'SELECT * FROM {ns}.employees').count()} rows.")
+display_df(spark.sql(f"SELECT * FROM {ns}.employees"))
+
+# 6. View snapshots and files (two snapshots now: create + append)
+print(f"\n6. Viewing snapshots and files for {ns}.employees:")
+print("   Snapshots:")
+display_df(spark.sql(f"SELECT * FROM {ns}.employees.snapshots"))
+print("   Data files:")
+display_df(spark.sql(f"SELECT * FROM {ns}.employees.files"))
+
+# 7. Time travel to the original version
+print(f"\n7. Time travel to original version (before append)...")
+first_snapshot = spark.sql(
+    f"SELECT snapshot_id FROM {ns}.employees.snapshots "
+    f"ORDER BY committed_at LIMIT 1"
+).collect()[0]["snapshot_id"]
+print(f"   First snapshot ID: {first_snapshot}")
+original = spark.sql(
+    f"SELECT * FROM {ns}.employees VERSION AS OF {first_snapshot}"
+)
+print(f"   Original version ({original.count()} rows, before append):")
+display_df(original)
+
+# 8. Tenant namespace (shared with your team)
+print("\n8. Creating tenant namespace and shared table...")
+tenant_ns = create_namespace_if_not_exists(
+    spark, "shared_data", tenant_name="globalusers"
+)
+print(f"   Tenant namespace: {tenant_ns}")
+df.writeTo(f"{tenant_ns}.team_employees").createOrReplace()
+print(f"   Table {tenant_ns}.team_employees created.")
+
+# 9. Cross-catalog query
+print(f"\n9. Cross-catalog query ({ns} + {tenant_ns}):")
+cross_result = spark.sql(f"""
+    SELECT * FROM {ns}.employees
+    UNION ALL
+    SELECT * FROM {tenant_ns}.team_employees
+""")
+display_df(cross_result)
+
+# 10. Schema evolution
+print(f"\n10. Adding 'email' column to {ns}.employees...")
+spark.sql(f"ALTER TABLE {ns}.employees ADD COLUMN email STRING")
+print(f"   Updated schema:")
+spark.sql(f"DESCRIBE {ns}.employees").show()
+display_df(spark.sql(f"SELECT * FROM {ns}.employees"))
+print("Done!")
+```
+
+## FAQ
+
+**Q: Do I need to change my `get_spark_session()` call?**
+No. `get_spark_session()` automatically configures both Delta and Iceberg catalogs. Your Polaris catalogs are ready to use.
+
+**Q: Can I still access my old Delta tables?**
+Yes. During the dual-read period, your Delta tables remain accessible at their original names (e.g., `u_{username}__analysis.my_table`). Iceberg copies are at `my.analysis.my_table`.
+
+**Q: What happened to my namespace prefixes (`u_{username}__`)?**
+They're no longer needed. With Iceberg, your personal catalog `my` is isolated at the catalog level — only you can access it. No prefix is required.
+
+**Q: How do I share data with my team?**
+Create a table in a tenant catalog:
+```python
+ns = create_namespace_if_not_exists(
+    spark, "shared_data", tenant_name="kbase"
+)
+df.writeTo(f"{ns}.my_shared_table").createOrReplace()
+```
+All members of the `kbase` tenant can read this table.
+
+**Q: Why does `DROP TABLE PURGE` leave files on S3?**
+This is a [known Iceberg bug](https://github.com/apache/iceberg/issues/14743) — Spark's `SparkCatalog` ignores the `PURGE` flag when talking to REST catalogs. `DROP TABLE` only removes the catalog entry. To delete the S3 files, use the MinIO client directly.
+
+**Q: Can I use `df.write.format("iceberg").saveAsTable(...)` instead of `writeTo`?**
+Yes, both work. `writeTo` is the recommended Iceberg API since it supports `createOrReplace()` and `append()` natively.

--- a/notebook_utils/berdl_notebook_utils/mcp/operations.py
+++ b/notebook_utils/berdl_notebook_utils/mcp/operations.py
@@ -71,7 +71,7 @@ def mcp_list_databases() -> list[str]:
     Databases are filtered by user/tenant namespace prefixes by default.
 
     Returns:
-        List of database names
+        List of database names (e.g., ['u_alice__demo', 'kbase_pangenome'])
 
     Raises:
         Exception: If the MCP server returns an error or is unreachable

--- a/notebook_utils/berdl_notebook_utils/spark/connect_server.py
+++ b/notebook_utils/berdl_notebook_utils/spark/connect_server.py
@@ -9,6 +9,7 @@ import logging
 import os
 import shutil
 import signal
+import socket
 import subprocess
 import time
 from pathlib import Path
@@ -288,8 +289,6 @@ class SparkConnectServerManager:
         Returns:
             True if port is free, False if timeout reached.
         """
-        import socket
-
         port = self.config.spark_connect_port
         start_time = time.time()
 
@@ -318,10 +317,13 @@ class SparkConnectServerManager:
         Returns:
             Dictionary with server information.
         """
-        # Check if server is already running
-        if self.is_running():
+        # Check if server is already running.
+        # Call get_server_info() once and reuse the result to avoid a TOCTOU
+        # race where the server could exit between is_running() and the
+        # follow-up get_server_info() returning None.
+        server_info = self.get_server_info()
+        if server_info is not None:
             if not force_restart:
-                server_info = self.get_server_info()
                 logger.info(f"✅ Spark Connect server already running (PID: {server_info['pid']})")
                 logger.info("   Reusing existing server - no need to start a new one")
                 return server_info
@@ -382,6 +384,12 @@ class SparkConnectServerManager:
                 f.write(str(process.pid))
 
             server_info = self.get_server_info()
+            if server_info is None:
+                raise RuntimeError(
+                    "Spark Connect process started but server info could not be read; "
+                    f"check logs: {self.config.log_file_path}"
+                )
+
             logger.info(f"✅ Spark Connect server started successfully (PID: {process.pid})")
             logger.info(f"   Connect URL: {server_info['url']}")
             logger.info(f"   Logs: {server_info['log_file']}")
@@ -401,18 +409,19 @@ class SparkConnectServerManager:
         Returns:
             Dictionary with status information.
         """
-        if self.is_running():
-            info = self.get_server_info()
+        # Single get_server_info() call (returns None if not running) avoids
+        # the TOCTOU race against a separate is_running() check.
+        info = self.get_server_info()
+        if info is not None:
             return {
                 "status": "running",
                 **info,
             }
-        else:
-            return {
-                "status": "stopped",
-                "port": self.config.spark_connect_port,
-                "url": f"sc://localhost:{self.config.spark_connect_port}",
-            }
+        return {
+            "status": "stopped",
+            "port": self.config.spark_connect_port,
+            "url": f"sc://localhost:{self.config.spark_connect_port}",
+        }
 
 
 # Public API - convenient functions for notebook users

--- a/notebook_utils/berdl_notebook_utils/spark/database.py
+++ b/notebook_utils/berdl_notebook_utils/spark/database.py
@@ -45,10 +45,7 @@ def generate_namespace_location(namespace: str | None = None, tenant_name: str |
     # `message` field but no `sql_warehouse_prefix` (e.g., user not in tenant).
     # Surface a warning and short-circuit instead of dereferencing None below.
     if hasattr(warehouse_response, "message") and not getattr(warehouse_response, "sql_warehouse_prefix", None):
-        print(
-            "Warning: Failed to get warehouse location: "
-            f"{getattr(warehouse_response, 'message', 'Unknown error')}"
-        )
+        print(f"Warning: Failed to get warehouse location: {getattr(warehouse_response, 'message', 'Unknown error')}")
         return (namespace, None)
 
     warehouse_dir = warehouse_response.sql_warehouse_prefix

--- a/notebook_utils/berdl_notebook_utils/spark/database.py
+++ b/notebook_utils/berdl_notebook_utils/spark/database.py
@@ -40,6 +40,17 @@ def generate_namespace_location(namespace: str | None = None, tenant_name: str |
     # Always fetch warehouse directory from governance API for proper S3 location
     # Don't rely on spark.sql.warehouse.dir as it may be set to local path by Spark Connect server
     warehouse_response = get_group_sql_warehouse(tenant_name) if tenant_name else get_my_sql_warehouse()
+
+    # Defensive: governance API may return an ErrorResponse-shaped object with a
+    # `message` field but no `sql_warehouse_prefix` (e.g., user not in tenant).
+    # Surface a warning and short-circuit instead of dereferencing None below.
+    if hasattr(warehouse_response, "message") and not getattr(warehouse_response, "sql_warehouse_prefix", None):
+        print(
+            "Warning: Failed to get warehouse location: "
+            f"{getattr(warehouse_response, 'message', 'Unknown error')}"
+        )
+        return (namespace, None)
+
     warehouse_dir = warehouse_response.sql_warehouse_prefix
 
     if warehouse_dir and ("users-sql-warehouse" in warehouse_dir or "tenant-sql-warehouse" in warehouse_dir):

--- a/notebook_utils/tests/spark/test_connect_server.py
+++ b/notebook_utils/tests/spark/test_connect_server.py
@@ -547,9 +547,9 @@ class TestSparkConnectServerManagerForceRestart:
     """Tests for force_restart functionality."""
 
     @patch("berdl_notebook_utils.spark.connect_server.SparkConnectServerManager.stop")
-    @patch("berdl_notebook_utils.spark.connect_server.SparkConnectServerManager.is_running")
+    @patch("berdl_notebook_utils.spark.connect_server.SparkConnectServerManager.get_server_info")
     @patch("berdl_notebook_utils.spark.connect_server.SparkConnectServerConfig")
-    def test_start_force_restart_calls_stop(self, mock_config_class, mock_is_running, mock_stop, tmp_path):
+    def test_start_force_restart_calls_stop(self, mock_config_class, mock_get_server_info, mock_stop, tmp_path):
         """Test start with force_restart=True calls stop first."""
         mock_config = Mock()
         mock_config.username = "test_user"
@@ -561,8 +561,10 @@ class TestSparkConnectServerManagerForceRestart:
         mock_config.pid_file_path = tmp_path / "pid"
         mock_config_class.return_value = mock_config
 
-        # Server is running initially
-        mock_is_running.side_effect = [True, False]  # First check: running, after stop: not running
+        # Server is running initially. After the TOCTOU-race fix in start(),
+        # the running-check is now a single get_server_info() call (not is_running()).
+        running_info = {"pid": 4321, "url": "sc://localhost:15002", "log_file": str(tmp_path / "log")}
+        mock_get_server_info.side_effect = [running_info, None]  # First check: running, after stop: not running
 
         # Mock the start script check to fail (we don't want to actually start)
         with patch("pathlib.Path.exists", return_value=False):

--- a/scripts/migrate_delta_to_iceberg.py
+++ b/scripts/migrate_delta_to_iceberg.py
@@ -1,0 +1,379 @@
+"""
+Delta Lake to Iceberg migration utilities for BERDL Phase 4.
+
+This script migrates Delta Lake tables (Hive Metastore) to Iceberg tables
+(Polaris REST catalog), preserving partitions and validating row counts.
+
+Functions:
+    migrate_table   - Migrate a single Delta table to an Iceberg catalog
+    migrate_user    - Migrate all of a user's Delta databases to their Iceberg catalog
+    migrate_tenant  - Migrate all of a tenant's Delta databases to their Iceberg catalog
+
+Usage in the migration notebook (migration_phase4.ipynb):
+
+    # Import after adding scripts/ to sys.path
+    from migrate_delta_to_iceberg import MigrationTracker, migrate_user, migrate_tenant
+
+    tracker = MigrationTracker()
+
+    # Migrate all tables for a user (idempotent — skips existing tables)
+    migrate_user(spark, "tgu2", target_catalog="user_tgu2", tracker=tracker)
+
+    # Migrate all tables for a tenant
+    migrate_tenant(spark, "globalusers", target_catalog="tenant_globalusers", tracker=tracker)
+
+    # View results
+    tracker.to_dataframe(spark).show(truncate=False)
+    print(tracker.summary())
+
+Force re-migration (drops existing Iceberg table and re-copies from Delta):
+
+    # Force re-migrate a single user table
+    migrate_table(
+        spark,
+        hive_db="u_tian_gu_test__demo_personal",
+        table_name="personal_test_table",
+        target_catalog="user_tian_gu_test",
+        target_ns="demo_personal",
+        tracker=tracker,
+        force=True,
+    )
+
+    # Force re-migrate a single tenant table
+    migrate_table(
+        spark,
+        hive_db="globalusers_demo_shared",
+        table_name="tenant_test_table",
+        target_catalog="tenant_globalusers",
+        target_ns="demo_shared",
+        tracker=tracker,
+        force=True,
+    )
+
+    # Force re-migrate all tables for a user
+    migrate_user(spark, "tian_gu_test", target_catalog="user_tian_gu_test", tracker=tracker, force=True)
+
+    # Force re-migrate all tables for a tenant
+    migrate_tenant(spark, "globalusers", target_catalog="tenant_globalusers", tracker=tracker, force=True)
+
+Note:
+    - Requires an admin Spark session configured with cross-user catalog access
+      (see Section 3 of migration_phase4.ipynb)
+    - By default, migration is idempotent: tables that already exist in the target
+      catalog are skipped. Use force=True to drop and re-migrate.
+    - DROP TABLE PURGE does not delete S3 data files due to an Iceberg bug (#14743).
+      To fully clean up, delete files from S3 directly using get_minio_client().
+"""
+
+import logging
+from dataclasses import dataclass, field
+
+from pyspark.sql import SparkSession
+
+logger = logging.getLogger(__name__)
+
+
+def _clean_error(e: Exception, max_len: int = 150) -> str:
+    """Extract a short, readable error message without JVM stacktraces."""
+    msg = str(e)
+    # Strip everything after "JVM stacktrace:" if present
+    if "JVM stacktrace:" in msg:
+        msg = msg[: msg.index("JVM stacktrace:")].strip()
+    # Take only the first line
+    msg = msg.split("\n")[0].strip()
+    if len(msg) > max_len:
+        msg = msg[:max_len] + "..."
+    return msg
+
+
+@dataclass
+class TableResult:
+    """Result of a single table migration."""
+
+    source: str
+    target: str
+    status: str  # "migrated", "skipped", "failed"
+    row_count: int = 0
+    error: str = ""
+
+
+@dataclass
+class MigrationTracker:
+    """Tracks migration progress across users and tenants."""
+
+    results: list[TableResult] = field(default_factory=list)
+
+    @property
+    def migrated(self) -> list[TableResult]:
+        return [r for r in self.results if r.status == "migrated"]
+
+    @property
+    def skipped(self) -> list[TableResult]:
+        return [r for r in self.results if r.status == "skipped"]
+
+    @property
+    def failed(self) -> list[TableResult]:
+        return [r for r in self.results if r.status == "failed"]
+
+    def add(self, result: TableResult):
+        self.results.append(result)
+
+    def summary(self) -> str:
+        return (
+            f"Total: {len(self.results)} | "
+            f"Migrated: {len(self.migrated)} | "
+            f"Skipped: {len(self.skipped)} | "
+            f"Failed: {len(self.failed)}"
+        )
+
+    def to_dataframe(self, spark: SparkSession):
+        """Convert results to a Spark DataFrame for notebook display."""
+        rows = [(r.source, r.target, r.status, r.row_count, r.error) for r in self.results]
+        return spark.createDataFrame(rows, ["source", "target", "status", "row_count", "error"])
+
+
+def _validate_target_catalog(spark: SparkSession, target_catalog: str) -> None:
+    """Raise ValueError if target_catalog is not configured in the Spark session.
+
+    Uses spark.conf.get() instead of SHOW CATALOGS because Spark lazily loads
+    catalogs — they won't appear in SHOW CATALOGS until first access.
+    """
+    config_key = f"spark.sql.catalog.{target_catalog}"
+    try:
+        spark.conf.get(config_key)
+    except Exception:
+        raise ValueError(
+            f"Catalog '{target_catalog}' is not configured in the current Spark session "
+            f"(no {config_key} property found). "
+            f"Did you run Section 3 (Configure Admin Spark) and restart Spark Connect?"
+        )
+
+
+def table_exists_in_catalog(spark: SparkSession, catalog: str, namespace: str, table_name: str) -> bool:
+    """Check if a table already exists in the target Iceberg catalog.
+
+    Uses SHOW TABLES instead of DESCRIBE TABLE to avoid JVM-level
+    TABLE_OR_VIEW_NOT_FOUND error logs when the table doesn't exist.
+    """
+    try:
+        tables = spark.sql(f"SHOW TABLES IN {catalog}.{namespace}").collect()
+        return any(row["tableName"] == table_name for row in tables)
+    except Exception:
+        return False
+
+
+def migrate_table(
+    spark: SparkSession,
+    hive_db: str,
+    table_name: str,
+    target_catalog: str,
+    target_ns: str,
+    tracker: MigrationTracker | None = None,
+    force: bool = False,
+):
+    """
+    Migrate a single Delta table to Iceberg via Polaris, preserving partitions.
+
+    Args:
+        spark: Active Spark session
+        hive_db: Original Hive/Delta database name
+        table_name: Original table name
+        target_catalog: Target Iceberg catalog name (e.g., 'my')
+        target_ns: Target namespace in Iceberg (e.g., 'test_db')
+        tracker: Optional MigrationTracker for progress tracking
+        force: If True, drop existing target table and re-migrate
+    """
+    source_ref = f"{hive_db}.{table_name}"
+    target_table_ref = f"{target_catalog}.{target_ns}.{table_name}"
+    print(f"  {source_ref} -> {target_table_ref}")
+    logger.info(f"Starting migration for {source_ref} -> {target_table_ref}")
+
+    # 0. Idempotency: skip if target already exists (unless force=True)
+    if table_exists_in_catalog(spark, target_catalog, target_ns, table_name):
+        if force:
+            logger.info(f"Force mode: dropping existing {target_table_ref}")
+            spark.sql(f"DROP TABLE {target_table_ref} PURGE")
+        else:
+            logger.info(f"Skipping {target_table_ref} — already exists in target catalog")
+            if tracker:
+                tracker.add(TableResult(source=source_ref, target=target_table_ref, status="skipped"))
+            return
+
+    # 1. Read from Delta using spark.table fallback
+    try:
+        df = spark.table(source_ref)
+    except Exception as e:
+        err_str = str(e)
+        if "DELTA_READ_TABLE_WITHOUT_COLUMNS" in err_str:
+            msg = "Delta table has no columns (empty schema) — skipping"
+            logger.warning(f"Skipping {source_ref} — {msg}")
+            if tracker:
+                tracker.add(TableResult(source=source_ref, target=target_table_ref, status="skipped", error=msg))
+            return
+        short_err = _clean_error(e)
+        print(f"    FAILED (read): {short_err}")
+        logger.error(f"Failed to read source table {source_ref}: {short_err}")
+        if tracker:
+            tracker.add(TableResult(source=source_ref, target=target_table_ref, status="failed", error=short_err))
+        return
+
+    # 1b. Skip tables with empty schema (corrupt Delta tables with no columns)
+    if len(df.columns) == 0:
+        msg = "Delta table has no columns (empty schema)"
+        logger.warning(f"Skipping {source_ref} — {msg}")
+        if tracker:
+            tracker.add(TableResult(source=source_ref, target=target_table_ref, status="skipped", error=msg))
+        return
+
+    # 2. Extract partition columns from the original Delta table
+    partition_cols: list[str] = []
+    try:
+        partition_cols = [row.name for row in spark.catalog.listColumns(f"{hive_db}.{table_name}") if row.isPartition]
+        if partition_cols:
+            logger.info(f"Found partition columns: {partition_cols}")
+    except Exception as e:
+        logger.warning(f"Could not fetch partitions for {source_ref} via catalog API: {e}")
+
+    # 3. Create target namespace, write data, and validate
+    try:
+        spark.sql(f"CREATE NAMESPACE IF NOT EXISTS {target_catalog}.{target_ns}")
+
+        # 4. Write as Iceberg (applying partition logic if it existed)
+        writer = df.writeTo(target_table_ref)
+        if partition_cols:
+            writer = writer.partitionedBy(*partition_cols)
+
+        logger.info(f"Writing data to {target_table_ref}...")
+        writer.create()
+        logger.info(f"Write completed for {target_table_ref}")
+
+        # 5. Validate row counts
+        original_count = spark.sql(f"SELECT COUNT(*) as cnt FROM {source_ref}").collect()[0]["cnt"]
+        migrated_count = spark.sql(f"SELECT COUNT(*) as cnt FROM {target_table_ref}").collect()[0]["cnt"]
+
+        if original_count != migrated_count:
+            msg = f"Row count mismatch: {original_count} vs {migrated_count}"
+            logger.error(f"Validation FAILED: {msg}")
+            if tracker:
+                tracker.add(
+                    TableResult(
+                        source=source_ref,
+                        target=target_table_ref,
+                        status="failed",
+                        row_count=migrated_count,
+                        error=msg,
+                    )
+                )
+            raise ValueError(msg)
+
+        logger.info(f"Validation SUCCESS: {migrated_count} rows migrated exactly.")
+        if tracker:
+            tracker.add(
+                TableResult(
+                    source=source_ref,
+                    target=target_table_ref,
+                    status="migrated",
+                    row_count=migrated_count,
+                )
+            )
+    except Exception as e:
+        short_err = _clean_error(e)
+        print(f"    FAILED: {short_err}")
+        logger.error(f"Failed to migrate {source_ref} -> {target_table_ref}: {short_err}")
+        if tracker and not any(r.target == target_table_ref for r in tracker.results):
+            tracker.add(TableResult(source=source_ref, target=target_table_ref, status="failed", error=short_err))
+
+
+def migrate_user(
+    spark: SparkSession,
+    username: str,
+    target_catalog: str = "my",
+    tracker: MigrationTracker | None = None,
+    force: bool = False,
+):
+    """
+    Migrate all of a user's Delta databases to their Iceberg catalog.
+
+    Args:
+        spark: Active SparkSession
+        username: The user's username
+        target_catalog: The target catalog (e.g., 'user_{username}')
+        tracker: Optional MigrationTracker for progress tracking
+        force: If True, drop existing target tables and re-migrate
+    """
+    _validate_target_catalog(spark, target_catalog)
+
+    prefix = f"u_{username}__"
+    databases = [db[0] for db in spark.sql("SHOW DATABASES").collect() if db[0].startswith(prefix)]
+
+    if not databases:
+        logger.info(f"No databases found for username {username} with prefix {prefix}")
+        return
+
+    for hive_db in databases:
+        iceberg_ns = hive_db.replace(prefix, "", 1)  # "u_tgu2__test_db" -> "test_db"
+        logger.info(f"Scanning database {hive_db}...")
+        try:
+            tables = spark.sql(f"SHOW TABLES IN {hive_db}").collect()
+        except Exception as e:
+            print(f"  Error listing tables in {hive_db}: {_clean_error(e)}")
+            continue
+
+        for table_row in tables:
+            table_name = table_row["tableName"]
+            try:
+                migrate_table(spark, hive_db, table_name, target_catalog, iceberg_ns, tracker, force=force)
+            except Exception as e:
+                print(f"    FAILED (unexpected): {_clean_error(e)}")
+
+
+def migrate_tenant(
+    spark: SparkSession,
+    tenant_name: str,
+    target_catalog: str,
+    tracker: MigrationTracker | None = None,
+    force: bool = False,
+):
+    """
+    Migrate all Delta databases for a tenant to their Iceberg catalog.
+
+    Tenant databases follow the pattern: {tenant_name}_{dbname} in Hive.
+    The {tenant_name}_ prefix is stripped to get the Iceberg namespace.
+
+    Args:
+        spark: Active SparkSession
+        tenant_name: The tenant/group name (e.g., 'kbase')
+        target_catalog: Target Iceberg catalog (e.g., 'tenant_kbase')
+        tracker: Optional MigrationTracker for progress tracking
+        force: If True, drop existing target tables and re-migrate
+    """
+    _validate_target_catalog(spark, target_catalog)
+
+    prefix = f"{tenant_name}_"
+    databases = [db[0] for db in spark.sql("SHOW DATABASES").collect() if db[0].startswith(prefix)]
+
+    if not databases:
+        logger.info(f"No databases found for tenant {tenant_name} with prefix {prefix}")
+        return
+
+    for hive_db in databases:
+        iceberg_ns = hive_db.replace(prefix, "", 1)
+        logger.info(f"Scanning tenant database {hive_db}...")
+        try:
+            tables = spark.sql(f"SHOW TABLES IN {hive_db}").collect()
+        except Exception as e:
+            print(f"  Error listing tables in {hive_db}: {_clean_error(e)}")
+            continue
+
+        for table_row in tables:
+            table_name = table_row["tableName"]
+            try:
+                migrate_table(spark, hive_db, table_name, target_catalog, iceberg_ns, tracker, force=force)
+            except Exception as e:
+                print(f"    FAILED (unexpected): {_clean_error(e)}")
+
+
+if __name__ == "__main__":
+    # If this is run independently we set up basic print logging
+    logging.basicConfig(level=logging.INFO, format="%(asctime)s - %(levelname)s - %(message)s")
+    print("Migration functions are loaded. Supply an active spark session to begin.")


### PR DESCRIPTION
First slice carved out of the large Polaris PR (#133). Every change here
is **100% backward-compatible** with the current main stack — verified
against:

- `spark_notebook_base` `main` (Iceberg JAR `iceberg-spark-runtime-4.0_:1.10.1` is already pinned in `build.gradle.kts`)
- `minio_manager_service` `main` (no API change required)
- `minio-manager-service-client` `v0.0.17` (current main pin in `pyproject.toml`)
- `datalake-mcp-server` `main` (no settings/contract change required)

## What's in

| File | Change |
|---|---|
| `scripts/migrate_delta_to_iceberg.py` (new, 379 LOC) | Standalone Delta→Iceberg migration utility. Imports only `pyspark` + stdlib — no `berdl_notebook_utils` dependencies — so it works against any Iceberg catalog the caller has registered. Used during cutover to copy Delta tables into Polaris Iceberg catalogs. |
| `docs/iceberg_migration_guide.md` (new, 444 LOC) | End-to-end migration / authoring guide for the Polaris Iceberg workflow. A status banner up top distinguishes today's main capabilities from the future Polaris API so reviewers don't get misled by the "After (Iceberg/Polaris)" code samples. |
| `configs/spark-defaults.conf.template` | Add `org.apache.iceberg.spark.extensions.IcebergSparkSessionExtensions` to `spark.sql.extensions`. The Iceberg JAR is already shipped in the base image; loading the extension class is harmless without a registered Iceberg catalog (it just enables Iceberg DDL parser support). Concrete catalogs are wired in per-session by future PRs. |
| `notebook_utils/berdl_notebook_utils/spark/connect_server.py` | TOCTOU race fix: `start()` and `status()` were calling `is_running()` then `get_server_info()` separately, which could return `None` if the server died between calls. Now a single `get_server_info()` call drives the decision. Also: `import socket` moved to top, and a `RuntimeError` guard after `subprocess.Popen` if the post-start `get_server_info()` returns `None` (instead of silently dereferencing). |
| `notebook_utils/berdl_notebook_utils/spark/database.py` | Defensive guard in `generate_namespace_location()`: short-circuit with a clear warning if the governance API returns an `ErrorResponse`-shaped object (e.g., user not in tenant) instead of dereferencing `None.sql_warehouse_prefix`. |
| `notebook_utils/berdl_notebook_utils/mcp/operations.py` | 1-line docstring example tweak. |
| `notebook_utils/tests/spark/test_connect_server.py` | `test_start_force_restart_calls_stop` now mocks `get_server_info` instead of `is_running` to match the race-fix refactor. |

## What's deliberately NOT in (will land in later phases)

- `regenerate_policies(exclude_users=…)` — mms `main` `regenerate_all_policies` route is body-less.
- `grant/revoke/list_namespace_access` notebook helpers — mms `main` has no `/namespace-access/*` routes.
- `MINIO_*` → `S3_*` env-var rename and `get_minio_client` → `get_s3_client` — Phase 1 lockstep across mms + mms-client + base + mcp.
- `get_polaris_catalog_info` / `provision_polaris_user` / `rotate_polaris_credentials` — Polaris router not yet mounted on mms `main`.
- `BERDL_HIVE_METASTORE_URI` made optional — separate small PR (Phase 0.5).
- `spark/_cache.py` + `data_store.py` rewrite — Iceberg-aware and Polaris-coupled; Phase 2.

## Tests

```
542 passed, 14 warnings in 3.06s
```

The 2 failing + 12 erroring tests in `tests/test_get_spark_session.py` and `tests/test_setup_trino_session.py` are **pre-existing on `origin/main`** (they require a live Spark/Trino) — confirmed by checking out plain main and re-running locally.

## Refs

- Carved from PR #133 (`feature/polaris`) per the phased decomposition plan.